### PR TITLE
Add basic test coverage for document parsing and hover

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -40,3 +40,63 @@ impl Document {
         tree.root_node().descendant_for_point_range(point, point)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_document(text: &str) -> Document {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_ifc::LANGUAGE.into())
+            .expect("Error loading IFC parser");
+
+        Document::parse(&mut parser, text.to_string())
+    }
+
+    fn position_at(text: &str, needle: &str) -> Position {
+        let offset = text.find(needle).expect("needle should exist") as u32;
+        Position::new(0, offset)
+    }
+
+    #[test]
+    fn parse_keeps_text_and_initial_state() {
+        let text = "#1=IFCWALL($);";
+        let document = parse_document(text);
+
+        assert_eq!(document.text, text);
+        assert!(document.tree.is_some());
+        assert_eq!(document.version, None);
+        assert!(document.definitions.is_empty());
+        assert!(document.references.is_empty());
+    }
+
+    #[test]
+    fn node_at_position_finds_entity_name() {
+        let text = "#1=IFCWALL($);";
+        let document = parse_document(text);
+
+        let node = document
+            .node_at_position(position_at(text, "IFCWALL"))
+            .expect("entity_name node should exist");
+
+        assert_eq!(node.kind(), "entity_name");
+        assert_eq!(
+            node.utf8_text(document.text.as_bytes()).ok(),
+            Some("IFCWALL")
+        );
+    }
+
+    #[test]
+    fn node_at_position_finds_reference() {
+        let text = "#1=IFCWALL(#2);";
+        let document = parse_document(text);
+
+        let node = document
+            .node_at_position(position_at(text, "#2"))
+            .expect("reference node should exist");
+
+        assert_eq!(node.kind(), "reference");
+        assert_eq!(node.utf8_text(document.text.as_bytes()).ok(), Some("#2"));
+    }
+}

--- a/src/features/hover.rs
+++ b/src/features/hover.rs
@@ -43,3 +43,69 @@ pub fn hover(document: &Document, position: Position, schema_docs: &SchemaDocs) 
         range: None,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn parse_document(text: &str) -> Document {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_ifc::LANGUAGE.into())
+            .expect("Error loading IFC parser");
+
+        Document::parse(&mut parser, text.to_string())
+    }
+
+    fn position_at(text: &str, needle: &str) -> Position {
+        let offset = text.find(needle).expect("needle should exist") as u32;
+        Position::new(0, offset)
+    }
+
+    fn hover_text(hover: Hover) -> String {
+        match hover.contents {
+            HoverContents::Markup(markup) => markup.value,
+            contents => panic!("unexpected hover contents: {contents:?}"),
+        }
+    }
+
+    #[test]
+    fn hover_returns_entity_placeholder_for_entity_names() {
+        let text = "#1=IFCWALL($);";
+        let document = parse_document(text);
+
+        let hover = hover(&document, position_at(text, "IFCWALL"), &SchemaDocs::new())
+            .expect("hover should exist");
+        let value = hover_text(hover);
+
+        assert!(value.contains("**IFCWALL**"));
+        assert!(value.contains("Documentation coming soon!"));
+    }
+
+    #[test]
+    fn hover_returns_generic_message_for_non_entity_name_nodes() {
+        let text = "#1=IFCWALL($);";
+        let document = parse_document(text);
+
+        let hover =
+            hover(&document, position_at(text, "#1"), &SchemaDocs::new()).expect("hover exists");
+        let value = hover_text(hover);
+
+        assert!(value.contains("Hover over an IFC entity name"));
+    }
+
+    #[test]
+    fn hover_returns_none_without_a_syntax_tree() {
+        let document = Document {
+            text: "#1=IFCWALL($);".to_string(),
+            tree: None,
+            version: None,
+            definitions: HashMap::new(),
+            references: HashMap::new(),
+        };
+
+        assert!(hover(&document, Position::new(0, 0), &SchemaDocs::new()).is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for Document::parse and Document::node_at_position
- add unit tests for current hover behavior, including entity and fallback cases
- keep test coverage focused on the features implemented so far

Closes #4