### PR TITLE
feat: add definition and references provider and document indexing

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -54,6 +54,7 @@ impl LanguageServer for Backend {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
                     TextDocumentSyncKind::FULL,
                 )),
+                definition_provider: Some(OneOf::Left(true)),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -55,6 +55,7 @@ impl LanguageServer for Backend {
                     TextDocumentSyncKind::FULL,
                 )),
                 definition_provider: Some(OneOf::Left(true)),
+                references_provider: Some(OneOf::Left(true)),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/document.rs
+++ b/src/document.rs
@@ -13,7 +13,7 @@ pub struct Document {
     pub text: String,
     pub tree: Option<Tree>,
     pub version: Option<IfcVersion>,
-    pub definitions: HashMap<u32, Range>,
+    pub definitions: HashMap<u32, Range>, // Changed the key from string to u32.
     pub references: HashMap<u32, Vec<Range>>,
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use tower_lsp::lsp_types::{Position, Range};
-use tree_sitter::{Node, Parser, Point, Tree};
+use tree_sitter::{Node, Parser, Point, Tree, TreeCursor};
 
 use crate::schema::IfcVersion;
 
@@ -13,21 +13,21 @@ pub struct Document {
     pub text: String,
     pub tree: Option<Tree>,
     pub version: Option<IfcVersion>,
-    pub definitions: HashMap<String, Range>,
-    pub references: HashMap<String, Vec<Range>>,
+    pub definitions: HashMap<u32, Range>,
+    pub references: HashMap<u32, Vec<Range>>,
 }
 
 impl Document {
     pub fn parse(parser: &mut Parser, text: String) -> Self {
         let tree = parser.parse(&text, None);
         let version = detect_version(&text);
-
+        let (definitions, references) = build_indexes(&tree, &text);
         Self {
             text,
             tree,
             version,
-            definitions: HashMap::new(),
-            references: HashMap::new(),
+            definitions: definitions,
+            references: references,
         }
     }
 
@@ -57,6 +57,76 @@ fn detect_version(text: &str) -> Option<IfcVersion> {
     }
 }
 
+fn build_indexes(
+    tree: &Option<Tree>,
+    text: &str,
+) -> (HashMap<u32, Range>, HashMap<u32, Vec<Range>>) {
+    let mut definitions = HashMap::new();
+    let mut references = HashMap::new();
+
+    let tree = match tree {
+        Some(t) => t,
+        None => return (definitions, references),
+    };
+
+    let mut cursor = tree.root_node().walk();
+    traverse(&mut cursor, text, &mut definitions, &mut references);
+
+    (definitions, references)
+}
+
+fn traverse(
+    cursor: &mut TreeCursor,
+    text: &str,
+    definitions: &mut HashMap<u32, Range>,
+    references: &mut HashMap<u32, Vec<Range>>,
+) {
+    loop {
+        let node = cursor.node();
+
+        if node.kind() == "entity_instance" {
+            if let Some(id_node) = node
+                .children(&mut cursor.clone())
+                .find(|c| c.kind() == "instance_id")
+            {
+                if let Ok(id_text) = id_node.utf8_text(text.as_bytes()) {
+                    if let Ok(id) = id_text.trim_start_matches('#').parse::<u32>() {
+                        let start = id_node.start_position();
+                        let end = id_node.end_position();
+                        definitions.insert(
+                            id,
+                            Range {
+                                start: Position::new(start.row as u32, start.column as u32),
+                                end: Position::new(end.row as u32, end.column as u32),
+                            },
+                        );
+                    }
+                }
+            }
+        } else if node.kind() == "reference" {
+            if let Ok(ref_text) = node.utf8_text(text.as_bytes()) {
+                if let Ok(id) = ref_text.trim_start_matches('#').parse::<u32>() {
+                    let start = node.start_position();
+                    let end = node.end_position();
+                    references.entry(id).or_insert_with(Vec::new).push(Range {
+                        start: Position::new(start.row as u32, start.column as u32),
+                        end: Position::new(end.row as u32, end.column as u32),
+                    });
+                }
+            }
+        }
+
+        if cursor.goto_first_child() {
+            traverse(cursor, text, definitions, references);
+            cursor.goto_parent();
+        }
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,12 +149,10 @@ mod tests {
     fn parse_keeps_text_and_initial_state() {
         let text = "#1=IFCWALL($);";
         let document = parse_document(text);
-
         assert_eq!(document.text, text);
         assert!(document.tree.is_some());
         assert_eq!(document.version, None);
-        assert!(document.definitions.is_empty());
-        assert!(document.references.is_empty());
+        // definitions and references are now populated, not empty
     }
 
     #[test]
@@ -114,5 +182,37 @@ mod tests {
 
         assert_eq!(node.kind(), "reference");
         assert_eq!(node.utf8_text(document.text.as_bytes()).ok(), Some("#2"));
+    }
+
+    #[test]
+    fn parse_indexes_entity_definition() {
+        let text = "#1=IFCWALL($);";
+        let document = parse_document(text);
+        assert!(document.definitions.contains_key(&1));
+        assert!(document.references.is_empty());
+    }
+
+    #[test]
+    fn parse_indexes_multiple_definitions() {
+        let text = "#1=IFCWALL($);\n#2=IFCDOOR($);";
+        let document = parse_document(text);
+        assert!(document.definitions.contains_key(&1));
+        assert!(document.definitions.contains_key(&2));
+        assert_eq!(document.definitions.len(), 2);
+    }
+
+    #[test]
+    fn parse_indexes_references() {
+        let text = "#1=IFCWALL(#2);";
+        let document = parse_document(text);
+        assert!(document.references.contains_key(&2));
+        assert_eq!(document.references[&2].len(), 1);
+    }
+
+    #[test]
+    fn parse_indexes_multiple_references_to_same_id() {
+        let text = "#1=IFCWALL(#2);\n#3=IFCDOOR(#2);";
+        let document = parse_document(text);
+        assert_eq!(document.references[&2].len(), 2);
     }
 }

--- a/src/features/definition.rs
+++ b/src/features/definition.rs
@@ -1,15 +1,26 @@
 //! Go-to-definition feature entry point.
-//! This module will resolve entity id references to local definitions.
-
-use tower_lsp::lsp_types::{GotoDefinitionResponse, Position, Url};
-
+//! Resolves entity id references to local definitions.
 use crate::document::Document;
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Url};
 
 pub fn goto_definition(
-    _uri: &Url,
+    uri: &Url,
     document: &Document,
-    _position: Position,
+    position: Position,
 ) -> Option<GotoDefinitionResponse> {
-    let _ = document.definitions.len();
-    None
+    let node = document.node_at_position(position)?;
+
+    let id = if node.kind() == "reference" {
+        let text = node.utf8_text(document.text.as_bytes()).ok()?;
+        text.trim_start_matches('#').parse::<u32>().ok()?
+    } else {
+        return None;
+    };
+
+    let range = document.definitions.get(&id)?;
+
+    Some(GotoDefinitionResponse::Scalar(Location {
+        uri: uri.clone(),
+        range: *range,
+    }))
 }

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -6,10 +6,39 @@ use tower_lsp::lsp_types::{Location, Position, Url};
 use crate::document::Document;
 
 pub fn find_references(
-    _uri: &Url,
+    uri: &Url,
     document: &Document,
-    _position: Position,
+    position: Position,
 ) -> Option<Vec<Location>> {
-    let _ = document.references.len();
-    None
+    let node = document.node_at_position(position)?;
+
+    let id_node = match node.kind() {
+        "instance_id" | "reference" => node,
+        _ => return None,
+    };
+
+    let text = id_node.utf8_text(document.text.as_bytes()).ok()?;
+    let id = text.trim_start_matches('#').parse::<u32>().ok()?;
+
+    let mut locations = Vec::new();
+
+    if let Some(range) = document.definitions.get(&id) {
+        locations.push(Location {
+            uri: uri.clone(),
+            range: *range,
+        });
+    }
+
+    if let Some(refs) = document.references.get(&id) {
+        locations.extend(refs.iter().map(|r| Location {
+            uri: uri.clone(),
+            range: *r,
+        }));
+    }
+
+    if locations.is_empty() {
+        None
+    } else {
+        Some(locations)
+    }
 }


### PR DESCRIPTION
- **implement indexing for definitions and references**
- **implemented definitions provider**
- **implemented references provider**

This PR implements both definition and references providers.
Should fix issues #6 and #2 

While working on the definition provider, I noticed that
we can build the definitions and references maps at the same time if we are already traversing the AST.
So i put both definition and reference provider in the same PR.

Changes:
- add indexing for entity definitions and references in Document
- implement go-to-definition provider
- implement find-references provider

Both features share the same traversal and data structures.
