### PR TITLE
switched from submodule to crates.io for tree-sitter-ifc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tree-sitter-ifc"]
-	path = tree-sitter-ifc
-	url = git@github.com:NepomukWolf/tree-sitter-ifc.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,8 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ifc"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209542697d854966be3c6f5c0bc405f81c4d4caf7d4b8602c85d37850bdc31b5"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ serde_json = "1"
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 tree-sitter = "0.26"
-tree-sitter-ifc = { path = "tree-sitter-ifc" }
+tree-sitter-ifc = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Coming soon!
 
 ### Grammar & Parser
 
-This project uses the [tree-sitter-ifc](https://github.com/NepomukWolf/tree-sitter-ifc) grammar. If you modify the grammar, regenerate the parser bindings with the standard `tree-sitter` build workflow.
+This project uses the published [`tree-sitter-ifc`](https://crates.io/crates/tree-sitter-ifc) crate for IFC parsing.
+
+If you are developing the grammar itself, work in the [`tree-sitter-ifc`](https://github.com/NepomukWolf/tree-sitter-ifc) repository and publish a new crate version when needed. During local development, you can temporarily override the crates.io dependency with a `[patch.crates-io]` entry that points at a local checkout.
 
 ### Running Tests
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,7 @@ If needed, entity-name lookup can either be derived from the syntax tree or stor
 
 ## tree-sitter Integration
 
-This repository includes the IFC grammar in the local [`tree-sitter-ifc`](/Users/benedict/repos/ifc-lsp/tree-sitter-ifc) directory.
-
-The main `ifc-lsp` crate depends on it as a local path dependency through `Cargo.toml`. At runtime, the language server creates a `tree_sitter::Parser`, loads the language from `tree_sitter_ifc`, and parses IFC source text into a `tree_sitter::Tree`.
+The main `ifc-lsp` crate depends on the published `tree-sitter-ifc` crate from crates.io. At runtime, the language server creates a `tree_sitter::Parser`, loads the language from `tree_sitter_ifc`, and parses IFC source text into a `tree_sitter::Tree`.
 
 That syntax tree is then used to:
 
@@ -84,7 +82,7 @@ That syntax tree is then used to:
 - distinguish entity names from entity references
 - support building the small per-document index used by hover, go-to-definition, and find-references
 
-The `tree-sitter-ifc` subdirectory should be treated as the source of truth for IFC syntax parsing, while the main crate should focus on indexing and LSP feature behavior built on top of that parse tree.
+The `tree-sitter-ifc` repository should be treated as the source of truth for IFC syntax parsing, while the main crate should focus on indexing and LSP feature behavior built on top of that parse tree.
 
 ## Feature Design
 


### PR DESCRIPTION
Integrate tree-sitter-ifc from crates.io instead of as a submodule. I also adjusted the docs to reflect this.