### PR TITLE
Make Documentation and Guidelines stricter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,6 @@ Build a release binary with:
 cargo build --release
 ```
 
-Run the server directly for debugging:
-
-```bash
-cargo run --release
-```
-
-The server communicates over `stdin`/`stdout` and is intended to be launched by an LSP client.
-
 ### Configuration
 
 The server accepts configuration through LSP `initializationOptions`.
@@ -112,13 +104,6 @@ Example `initializationOptions`:
 This project depends on the published [`tree-sitter-ifc`](https://crates.io/crates/tree-sitter-ifc) crate for IFC parsing.
 
 If you are developing the grammar itself, work in the [`tree-sitter-ifc`](https://github.com/NepomukWolf/tree-sitter-ifc) repository and publish a new crate version when needed. During local development, you can temporarily override the crates.io dependency with a `[patch.crates-io]` entry that points at a local checkout.
-
-### Formatting
-
-This project uses:
-
-- `rustfmt` for Rust via `cargo fmt`
-- Prettier for Markdown
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -255,23 +255,9 @@ samples/
   *.ifc
 ```
 
-## Testing Approach
-
-Tests currently live next to the implementation in the same Rust modules.
-
-Existing tests mainly cover:
-
-- document parsing and index building
-- schema-doc loading
-- EXPRESS schema loading and resolution
-- datatype diagnostics behavior
-- hover rendering behavior
-
-There is not yet dedicated test coverage for the definition and references modules, even though those features are implemented.
-
 ## Non-Goals For The Current Architecture
 
-The current project should continue to avoid:
+The current project should continue to avoid the following, unless explicitely requested by the user:
 
 - cross-file indexing
 - incremental parsing infrastructure

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -37,7 +37,7 @@ Prefer the simplest implementation that matches the documented current scope in 
 - New crates require explicit approval before being added.
   - Avoid adding crates unless they are clearly necessary.
   - Prefer the standard library or existing dependencies for small tasks.
-- Major architectural require approval.
+- Major architectural changes require approval.
 - Large refactors require approval.
 - No modifications to `./docs` without specific instructions by the user.
 - No deleting, resetting, or reverting unrelated work without approval.

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -14,16 +14,6 @@ Code in this repository should be:
 
 Prefer the simplest implementation that matches the documented current scope in `requirements.md`.
 
-## Rust Formatting
-
-All Rust code must be formatted with `rustfmt`.
-
-Before finishing a Rust change, run:
-
-```sh
-cargo fmt
-```
-
 ## Architectural Discipline
 
 - Keep changes aligned with the current `Backend` / `Document` / `SchemaDocCollection` split.
@@ -40,12 +30,18 @@ cargo fmt
 - Reuse existing helpers before adding new ones.
 - Add comments only when the intent is not obvious from the code itself.
 - Avoid dead code, placeholder branches, and speculative abstractions.
+- When creating a new module, add descriptive comments explaining its purpose.
 
-## Dependencies
+## Approval Boundaries
 
-- Avoid adding crates unless they are clearly necessary.
 - New crates require explicit approval before being added.
-- Prefer the standard library or existing dependencies for small tasks.
+  - Avoid adding crates unless they are clearly necessary.
+  - Prefer the standard library or existing dependencies for small tasks.
+- Major architectural require approval.
+- Large refactors require approval.
+- No modifications to `./docs` without specific instructions by the user.
+- No deleting, resetting, or reverting unrelated work without approval.
+- Ask the user when encountering ambiguous requirements, conflicting docs, or risky edits.
 
 ## Error Handling
 
@@ -59,11 +55,22 @@ cargo fmt
 - Prefer small unit tests close to the code they exercise.
 - Test behavior, not implementation noise.
 - When changing parsing, indexing, version detection, schema loading, or hover rendering, update tests in the same module.
-- Add targeted tests for definition and references behavior when changing those modules, since current coverage there is thin.
 - Use short IFC snippets in tests unless a repository sample file is clearly more useful.
+- Note: Builds require internet access due to the EXPRESS schema pulling at compile time in `build.rs`.
 
 ## Scope Discipline
 
 - Implement only what is required by the current issue or the documented current scope.
 - Do not silently broaden the project into diagnostics, workspace indexing, or additional LSP features.
 - If a design can be simpler, prefer the simpler version.
+
+## Verification Gate
+
+The following commands must pass for a change to be verified:
+
+```bash
+cargo fmt --check
+cargo test --locked
+```
+
+If the tests fail repeatedly when implementing a new feature, the run should be halted and the issues presented to the user.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -23,10 +23,6 @@ For these officially supported versions:
 
 ## Features
 
-### IFC STEP P21 Syntax Highlighting
-
-The language server should support syntax highlighting for IFC STEP P21 files.
-
 ### Hover
 
 #### Entity Definition Hover
@@ -67,3 +63,17 @@ The LS should provide schema-aware diagnostics for things like:
 - Entity Schema Compliance (e.g., IFCALIGNMENT is not part of IFC2x3)
 
 Appropriate user-facing information (underlining, hover text) is part of the diagnostics.
+
+### Custom EXPRESS Schemas
+
+Next to the built-in support for the three major versions of IFC, the user should be able to add support for more schema versions via EXPRESS definition files. This functionality is exposed via the `initializationOptions`. Both forcing a specific schema (`overwriteExpSchemaWithLocal`) and adding to the existing list of schemas (`addLocalSchemaToSelection`) are supported. Examples Configuration:
+
+```json
+{
+  "overwriteExpSchemaWithLocal": "/Users/alice/dev/express/IFC4x2.exp",
+  "addLocalSchemaToSelection": [
+    "/Users/alice/dev/express/IFC4x1.exp",
+    "/Users/alice/dev/express/custom-schemas"
+  ]
+}
+```


### PR DESCRIPTION
Make the documentation and agent guidelines stricter:
- Add a formal verification gate.
- Define clearer boundaries for when user approval is required.
- Remove unnecessary lines from the README.
- Add custom EXPRESS schema functionality to the requirements.

Solves #47.