### PR TITLE
Add SHA256 checksums to build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,12 +146,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -169,6 +197,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -323,6 +361,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -489,6 +537,7 @@ name = "ifc-language-server"
 version = "0.2.0"
 dependencies = [
  "espr",
+ "sha2",
  "tokio",
  "tower-lsp",
  "tree-sitter",
@@ -903,6 +952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1287,12 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ tree-sitter = "0.26"
 tree-sitter-ifc = "0.1.0"
 
 [build-dependencies]
+sha2 = "0.10"
 ureq = "3"

--- a/build.rs
+++ b/build.rs
@@ -1,24 +1,25 @@
-//! Build-time bundling of official IFC EXPRESS definitions.
-//! The three supported schemas are downloaded during compilation and written into `OUT_DIR` so the
-//! runtime can include them in the binary without storing EXPRESS files in the repository.
-
 use std::env;
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
 
-const SCHEMAS: &[(&str, &str)] = &[
+use sha2::{Digest, Sha256};
+
+const SCHEMAS: &[(&str, &str, &str)] = &[
     (
         "ifc2x3_tc1.exp",
         "https://standards.buildingsmart.org/IFC/RELEASE/IFC2x3/TC1/EXPRESS/IFC2X3_TC1.exp",
+        "e18a1b2c3e29f5256904c83378ccad0850f52287a8d0122d149aba4a417fe5e5",
     ),
     (
         "ifc4_add2_tc1.exp",
         "https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2_TC1/EXPRESS/IFC4.exp",
+        "a2704ba20a1b3d0b7d9b61d6fd37d0baa3b4996ba3e90d968a1d2ca2819d1046",
     ),
     (
         "ifc4x3_add2.exp",
         "https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/IFC4X3_ADD2.exp",
+        "f67c8762b13a099c28082061e6f16b9ef1284ceec34069792afc702725675860",
     ),
 ];
 
@@ -28,8 +29,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?).join("express");
     fs::create_dir_all(&out_dir)?;
 
-    for (file_name, url) in SCHEMAS {
-        let source = ureq::get(*url).call()?.body_mut().read_to_string()?;
+    for (file_name, url, expected_sha256) in SCHEMAS {
+        let source = ureq::get(*url).call()?.body_mut().read_to_vec()?;
+        let actual_sha256 = format!("{:x}", Sha256::digest(&source));
+
+        if actual_sha256 != *expected_sha256 {
+            return Err(format!(
+                "checksum mismatch for {}: expected {}, got {}",
+                file_name, expected_sha256, actual_sha256
+            )
+            .into());
+        }
+
         fs::write(out_dir.join(file_name), source)?;
     }
 


### PR DESCRIPTION
This commit add SHA256 verification at compile time for the EXPRESS definition files. This way, the build will fail should the express files for the 3 officially supported versions change in any capacity. This ensures that we stay up to date AND make it easier to identify EXPRESS schema related errors in the future.

sha2 was added as a build-dependency only, so this does not make the compiled binary any larger. Closes #46 