### PR TITLE
add hover for *

### DIFF
--- a/src/diagnostics/datatype.rs
+++ b/src/diagnostics/datatype.rs
@@ -497,6 +497,7 @@ mod tests {
                     },
                 ],
             }],
+            instance_indexes_by_id: HashMap::from([(1, 0)]),
         };
 
         let schema = schema_from(

--- a/src/document.rs
+++ b/src/document.rs
@@ -16,6 +16,7 @@ pub struct Document {
     pub definitions: HashMap<u32, DefinitionInfo>,
     pub references: HashMap<u32, Vec<Range>>,
     pub instances: Vec<EntityInstanceInfo>,
+    pub(crate) instance_indexes_by_id: HashMap<u32, usize>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -114,6 +115,11 @@ impl Document {
         let tree = parser.parse(&text, None);
         let schema_name = detect_schema(&tree, &text);
         let (definitions, references, instances) = build_indexes(&tree, &text);
+        let instance_indexes_by_id = instances
+            .iter()
+            .enumerate()
+            .filter_map(|(index, instance)| instance.id.map(|id| (id, index)))
+            .collect();
         Self {
             text,
             tree,
@@ -121,6 +127,7 @@ impl Document {
             definitions,
             references,
             instances,
+            instance_indexes_by_id,
         }
     }
 
@@ -132,6 +139,12 @@ impl Document {
         };
 
         tree.root_node().descendant_for_point_range(point, point)
+    }
+
+    pub fn instance_by_id(&self, id: u32) -> Option<&EntityInstanceInfo> {
+        self.instance_indexes_by_id
+            .get(&id)
+            .and_then(|index| self.instances.get(*index))
     }
 }
 
@@ -556,5 +569,15 @@ mod tests {
         let text = "#1=IFCWALL(#2);\n#3=IFCDOOR(#2);";
         let document = parse_document(text);
         assert_eq!(document.references[&2].len(), 2);
+    }
+
+    #[test]
+    fn instance_by_id_returns_matching_instance() {
+        let text = "#1=IFCWALL($);\n#2=IFCDOOR($);";
+        let document = parse_document(text);
+
+        let instance = document.instance_by_id(2).expect("instance should exist");
+
+        assert_eq!(instance.entity_name, "IFCDOOR");
     }
 }

--- a/src/features/hover.rs
+++ b/src/features/hover.rs
@@ -7,6 +7,7 @@ use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Posi
 
 use crate::document::{DefinitionInfo, Document};
 use crate::schema::{EntityAttributeDoc, EntityDoc, SchemaDocCollection};
+use crate::step::{ast, derived, derived::ResolvedDerivedValue};
 
 pub fn hover(
     document: &Document,
@@ -42,6 +43,29 @@ pub fn hover(
                 }),
                 range: Some(node_range(&node)),
             });
+        } else if node.kind() == "omitted_value" {
+            if let Some(schema_name) = selected_schema_name.or(document.schema_name.as_deref())
+                && let Some(schema) = schema_docs.get(schema_name)
+            {
+                let context = ast::omitted_value_context(node, &document.text)?;
+                return Some(Hover {
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: omitted_value_hover(
+                            document,
+                            schema,
+                            derived::resolve_omitted_value(
+                                document,
+                                schema,
+                                context.instance_id,
+                                &context.entity_name,
+                                context.parameter_index,
+                            )?,
+                        )?,
+                    }),
+                    range: Some(node_range(&node)),
+                });
+            }
         }
     }
 
@@ -100,6 +124,26 @@ fn render_reference_hover(document: &Document, definition: &DefinitionInfo) -> O
     let preview = extract_range_text(document, definition.entity_range)?;
 
     Some(format!("```ifc\n{}\n```", preview.trim()))
+}
+
+fn omitted_value_hover(
+    _document: &Document,
+    _schema: &crate::schema::SchemaDoc,
+    resolved: ResolvedDerivedValue,
+) -> Option<String> {
+    let mut text = match resolved.value {
+        Some(value) => format!("{}: {}", resolved.attribute_name, value),
+        None => format!("{}: derived value", resolved.attribute_name),
+    };
+    if let Some(preview) = resolved.preview {
+        text.push_str("\n\n");
+        text.push_str(&preview);
+    }
+    if let Some(note) = resolved.resolution_note {
+        text.push_str("\n\n");
+        text.push_str(&note);
+    }
+    Some(text)
 }
 
 fn extract_range_text(document: &Document, range: tower_lsp::lsp_types::Range) -> Option<&str> {
@@ -215,6 +259,64 @@ mod tests {
         SchemaDocCollection::from_docs([("IFC4".to_string(), schema)])
     }
 
+    fn schema_docs_with_derived_attributes() -> SchemaDocCollection {
+        let source = r#"
+        SCHEMA IFC4;
+          TYPE IfcUnitEnum = ENUMERATION OF (LENGTHUNIT, AREAUNIT, VOLUMEUNIT, PLANEANGLEUNIT);
+          END_TYPE;
+          TYPE IfcSIPrefix = ENUMERATION OF (MILLI);
+          END_TYPE;
+          TYPE IfcSIUnitName = ENUMERATION OF (METRE, SQUARE_METRE, CUBIC_METRE, RADIAN);
+          END_TYPE;
+          TYPE IfcGeometricProjectionEnum = ENUMERATION OF (MODEL_VIEW, PLAN_VIEW);
+          END_TYPE;
+          ENTITY IfcDimensionalExponents;
+          END_ENTITY;
+          ENTITY IfcAxis2Placement3D;
+          END_ENTITY;
+          ENTITY IfcDirection;
+          END_ENTITY;
+          ENTITY IfcNamedUnit;
+            Dimensions : IfcDimensionalExponents;
+            UnitType : IfcUnitEnum;
+          END_ENTITY;
+          ENTITY IfcSIUnit
+            SUBTYPE OF (IfcNamedUnit);
+            Prefix : OPTIONAL IfcSIPrefix;
+            Name : IfcSIUnitName;
+          DERIVE
+            SELF\IfcNamedUnit.Dimensions : IfcDimensionalExponents := ?;
+          END_ENTITY;
+          ENTITY IfcRepresentationContext;
+            ContextIdentifier : OPTIONAL STRING;
+            ContextType : OPTIONAL STRING;
+            CoordinateSpaceDimension : INTEGER;
+            Precision : OPTIONAL REAL;
+            WorldCoordinateSystem : IfcAxis2Placement3D;
+            TrueNorth : OPTIONAL IfcDirection;
+          END_ENTITY;
+          ENTITY IfcGeometricRepresentationContext
+            SUBTYPE OF (IfcRepresentationContext);
+          END_ENTITY;
+          ENTITY IfcGeometricRepresentationSubContext
+            SUBTYPE OF (IfcGeometricRepresentationContext);
+            ParentContext : IfcRepresentationContext;
+            TargetScale : OPTIONAL REAL;
+            TargetView : IfcGeometricProjectionEnum;
+            UserDefinedTargetView : OPTIONAL STRING;
+          DERIVE
+            SELF\IfcRepresentationContext.CoordinateSpaceDimension : INTEGER := ?;
+            SELF\IfcRepresentationContext.Precision : REAL := ?;
+            SELF\IfcRepresentationContext.WorldCoordinateSystem : IfcAxis2Placement3D := ?;
+            SELF\IfcRepresentationContext.TrueNorth : IfcDirection := ?;
+          END_ENTITY;
+        END_SCHEMA;
+        "#;
+        let schema = crate::schema::load_express(crate::schema::IfcVersion::Ifc4Add2Tc1, source)
+            .expect("fixture schema should parse");
+        SchemaDocCollection::from_docs([("IFC4".to_string(), schema)])
+    }
+
     #[test]
     fn hover_returns_schema_docs_for_entity_names_with_detected_version() {
         let text = "ISO-10303-21;HEADER;FILE_SCHEMA(('IFC4'));ENDSEC;DATA;#1=IFCWALL($);ENDSEC;END-ISO-10303-21;";
@@ -231,6 +333,22 @@ mod tests {
 
         assert!(value.contains("# IfcWall"));
         assert!(value.contains("Official documentation"));
+    }
+
+    #[test]
+    fn omitted_value_context_uses_ast_to_find_instance_and_parameter() {
+        let text = "#15=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);";
+        let document = parse_document(text);
+        let node = document
+            .node_at_position(position_at(text, "*"))
+            .expect("omitted value node should exist");
+
+        let context = crate::step::ast::omitted_value_context(node, &document.text)
+            .expect("context should resolve from AST");
+
+        assert_eq!(context.instance_id, 15);
+        assert_eq!(context.entity_name, "IFCSIUNIT");
+        assert_eq!(context.parameter_index, 0);
     }
 
     #[test]
@@ -265,6 +383,107 @@ mod tests {
     }
 
     #[test]
+    fn hover_returns_resolved_value_for_ifc_si_unit_omitted_dimensions() {
+        let text = "#15=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);";
+        let document = parse_document(text);
+
+        let hover = hover(
+            &document,
+            position_at(text, "*"),
+            &schema_docs_with_derived_attributes(),
+            Some("IFC4"),
+        )
+        .expect("hover should exist");
+        let value = hover_text(hover);
+
+        assert!(value.contains("Dimensions"));
+        assert!(value.contains("IfcDimensionalExponents(1, 0, 0, 0, 0, 0, 0)"));
+        assert!(value.contains("resolved from `Name`"));
+    }
+
+    #[test]
+    fn hover_returns_resolved_zero_dimensions_for_radian() {
+        let text = "#18=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);";
+        let document = parse_document(text);
+
+        let hover = hover(
+            &document,
+            position_at(text, "*"),
+            &schema_docs_with_derived_attributes(),
+            Some("IFC4"),
+        )
+        .expect("hover should exist");
+        let value = hover_text(hover);
+
+        assert!(value.contains("Dimensions"));
+        assert!(value.contains("IfcDimensionalExponents(0, 0, 0, 0, 0, 0, 0)"));
+    }
+
+    #[test]
+    fn hover_resolves_subcontext_value_from_parent_context() {
+        let text = "#7=IFCAXIS2PLACEMENT3D();\n#11=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,$,#7,$);\n#12=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#11,$,.MODEL_VIEW.,$);";
+        let document = parse_document(text);
+
+        let hover = hover(
+            &document,
+            position_at_last(text, "*"),
+            &schema_docs_with_derived_attributes(),
+            Some("IFC4"),
+        )
+        .expect("hover should exist");
+        let value = hover_text(hover);
+
+        assert!(value.contains("TrueNorth"));
+        assert!(value.contains("TrueNorth: `$`"));
+        assert!(value.contains("resolved from `ParentContext`"));
+    }
+
+    #[test]
+    fn hover_resolves_subcontext_reference_from_parent_context() {
+        let text = "#7=IFCAXIS2PLACEMENT3D();\n#11=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,$,#7,$);\n#12=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#11,$,.MODEL_VIEW.,$);";
+        let document = parse_document(text);
+        let first_star = text.match_indices('*').nth(2).expect("third star exists").0 as u32;
+        let prefix = &text[..first_star as usize];
+        let line = prefix.bytes().filter(|&b| b == b'\n').count() as u32;
+        let column = prefix
+            .rsplit_once('\n')
+            .map(|(_, tail)| tail.len() as u32)
+            .unwrap_or(first_star);
+
+        let hover = hover(
+            &document,
+            Position::new(line, column),
+            &schema_docs_with_derived_attributes(),
+            Some("IFC4"),
+        )
+        .expect("hover should exist");
+        let value = hover_text(hover);
+
+        assert!(value.contains("WorldCoordinateSystem"));
+        assert!(value.contains("`#7`"));
+        assert!(value.contains("#7=IFCAXIS2PLACEMENT3D();"));
+        assert!(value.contains("resolved from `ParentContext`"));
+    }
+
+    #[test]
+    fn hover_explains_unresolved_parent_context() {
+        let text = "#12=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#99,$,.MODEL_VIEW.,$);";
+        let document = parse_document(text);
+
+        let hover = hover(
+            &document,
+            position_at(text, "*"),
+            &schema_docs_with_derived_attributes(),
+            Some("IFC4"),
+        )
+        .expect("hover should exist");
+        let value = hover_text(hover);
+
+        assert!(value.contains("CoordinateSpaceDimension"));
+        assert!(value.contains("derived value"));
+    }
+
+    #[test]
     fn hover_returns_none_without_a_syntax_tree() {
         let document = Document {
             text: "#1=IFCWALL($);".to_string(),
@@ -273,6 +492,7 @@ mod tests {
             definitions: HashMap::new(),
             references: HashMap::new(),
             instances: Vec::new(),
+            instance_indexes_by_id: HashMap::new(),
         };
 
         assert!(hover(&document, Position::new(0, 0), &empty_schema_docs(), None).is_none());

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod diagnostics;
 mod document;
 mod features;
 mod schema;
+mod step;
 
 use backend::Backend;
 use tower_lsp::{LspService, Server};

--- a/src/step/ast.rs
+++ b/src/step/ast.rs
@@ -1,0 +1,66 @@
+//! Tree-sitter helpers for locating STEP instance and parameter context around a cursor node.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OmittedValueContext {
+    pub instance_id: u32,
+    pub entity_name: String,
+    pub parameter_index: usize,
+}
+
+pub fn omitted_value_context(
+    node: tree_sitter::Node<'_>,
+    text: &str,
+) -> Option<OmittedValueContext> {
+    let parameter = ancestor_with_kind(node, "parameter")?;
+    let parameter_sequence = ancestor_with_kind(parameter, "parameter_sequence")?;
+    let entity_instance = ancestor_with_kind(parameter_sequence, "entity_instance")?;
+
+    Some(OmittedValueContext {
+        instance_id: parse_instance_id(entity_instance, text)?,
+        entity_name: parse_entity_name(entity_instance, text)?,
+        parameter_index: parameter_index(parameter_sequence, parameter)?,
+    })
+}
+
+fn ancestor_with_kind<'tree>(
+    mut node: tree_sitter::Node<'tree>,
+    expected_kind: &str,
+) -> Option<tree_sitter::Node<'tree>> {
+    loop {
+        if node.kind() == expected_kind {
+            return Some(node);
+        }
+        node = node.parent()?;
+    }
+}
+
+fn parse_instance_id(node: tree_sitter::Node<'_>, text: &str) -> Option<u32> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|child| child.kind() == "instance_id")
+        .and_then(|child| child.utf8_text(text.as_bytes()).ok())
+        .and_then(|value| value.trim_start_matches('#').parse::<u32>().ok())
+}
+
+fn parse_entity_name(node: tree_sitter::Node<'_>, text: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|child| child.kind() == "entity_name")
+        .and_then(|child| child.utf8_text(text.as_bytes()).ok())
+        .map(|value| value.to_ascii_uppercase())
+}
+
+fn parameter_index(
+    parameter_sequence: tree_sitter::Node<'_>,
+    parameter: tree_sitter::Node<'_>,
+) -> Option<usize> {
+    let mut cursor = parameter_sequence.walk();
+    parameter_sequence
+        .children(&mut cursor)
+        .filter(|child| child.kind() == "parameter")
+        .position(|child| same_node(child, parameter))
+}
+
+fn same_node(a: tree_sitter::Node<'_>, b: tree_sitter::Node<'_>) -> bool {
+    a.start_byte() == b.start_byte() && a.end_byte() == b.end_byte()
+}

--- a/src/step/derived.rs
+++ b/src/step/derived.rs
@@ -1,0 +1,207 @@
+//! Resolution of STEP `*` values for the currently supported IFC derived-attribute cases.
+
+use crate::document::{Document, EntityInstanceInfo, ParameterValue};
+use crate::schema::{EntityAttributeDoc, EntityDoc, SchemaDoc};
+
+pub struct ResolvedDerivedValue {
+    pub attribute_name: String,
+    pub value: Option<String>,
+    pub preview: Option<String>,
+    pub resolution_note: Option<String>,
+}
+
+pub fn resolve_omitted_value(
+    document: &Document,
+    schema: &SchemaDoc,
+    instance_id: u32,
+    entity_name: &str,
+    parameter_index: usize,
+) -> Option<ResolvedDerivedValue> {
+    let instance = document.instance_by_id(instance_id)?;
+    let entity_doc = schema.entity(entity_name)?;
+    let attribute = entity_doc.attributes.get(parameter_index)?;
+    if !attribute.allows_omitted {
+        return None;
+    }
+
+    let resolution = resolve_derived_attribute(document, schema, instance, entity_doc, attribute);
+    Some(ResolvedDerivedValue {
+        attribute_name: attribute.name.clone(),
+        value: resolution.as_ref().map(|value| value.value.clone()),
+        preview: resolution.as_ref().and_then(|value| value.preview.clone()),
+        resolution_note: resolution.and_then(|value| value.resolution_note),
+    })
+}
+
+fn resolve_derived_attribute(
+    document: &Document,
+    schema: &SchemaDoc,
+    instance: &EntityInstanceInfo,
+    entity_doc: &EntityDoc,
+    attribute: &EntityAttributeDoc,
+) -> Option<ResolvedParameterValue> {
+    match (entity_doc.name.as_str(), attribute.name.as_str()) {
+        ("IfcSIUnit", "Dimensions") => resolve_ifc_si_unit_dimensions(instance, entity_doc),
+        ("IfcGeometricRepresentationSubContext", _) => {
+            resolve_subcontext_parent_value(document, schema, instance, attribute)
+        }
+        _ => None,
+    }
+}
+
+fn resolve_ifc_si_unit_dimensions(
+    instance: &EntityInstanceInfo,
+    entity_doc: &EntityDoc,
+) -> Option<ResolvedParameterValue> {
+    let unit_name = instance
+        .parameters
+        .iter()
+        .zip(&entity_doc.attributes)
+        .find_map(
+            |(value, attribute)| match (attribute.name.as_str(), value) {
+                ("Name", ParameterValue::Enumeration { value, .. }) => Some(value.as_str()),
+                _ => None,
+            },
+        )?;
+    let dimensions = ifc_dimensions_for_si_unit(unit_name)?;
+
+    Some(ResolvedParameterValue {
+        value: format!(
+            "`IfcDimensionalExponents({}, {}, {}, {}, {}, {}, {})`",
+            dimensions[0],
+            dimensions[1],
+            dimensions[2],
+            dimensions[3],
+            dimensions[4],
+            dimensions[5],
+            dimensions[6],
+        ),
+        preview: None,
+        resolution_note: Some("resolved from `Name`".to_string()),
+    })
+}
+
+fn resolve_subcontext_parent_value(
+    document: &Document,
+    schema: &SchemaDoc,
+    instance: &EntityInstanceInfo,
+    attribute: &EntityAttributeDoc,
+) -> Option<ResolvedParameterValue> {
+    let parent_context_id = instance
+        .parameters
+        .iter()
+        .zip(schema.entity(&instance.entity_name)?.attributes.iter())
+        .find_map(|(value, attr)| match (attr.name.as_str(), value) {
+            ("ParentContext", ParameterValue::Reference { id, .. }) => Some(*id),
+            _ => None,
+        })?;
+    let parent_instance = document.instance_by_id(parent_context_id)?;
+    let parent_entity = schema.entity(&parent_instance.entity_name)?;
+    let parent_index = parent_entity
+        .attributes
+        .iter()
+        .position(|candidate| candidate.name == attribute.name)?;
+    let parent_value = parent_instance.parameters.get(parent_index)?;
+
+    let (value, preview) = render_parameter_resolution(document, parent_value)?;
+
+    Some(ResolvedParameterValue {
+        value,
+        preview,
+        resolution_note: Some("resolved from `ParentContext`".to_string()),
+    })
+}
+
+fn render_parameter_resolution(
+    document: &Document,
+    value: &ParameterValue,
+) -> Option<(String, Option<String>)> {
+    match value {
+        ParameterValue::Reference { id, .. } => {
+            let definition = document.definitions.get(id)?;
+            Some((
+                format!("`#{}`", id),
+                Some(format!(
+                    "```ifc\n{}\n```",
+                    extract_range_text(document, definition.entity_range)?.trim()
+                )),
+            ))
+        }
+        ParameterValue::Enumeration { value, .. } => Some((format!("`.{}.`", value), None)),
+        ParameterValue::Number { text, .. } => Some((format!("`{}`", text), None)),
+        ParameterValue::Null { .. } => Some(("`$`".to_string(), None)),
+        ParameterValue::String { .. } => Some(("string value".to_string(), None)),
+        ParameterValue::Omitted { .. } => Some(("`*`".to_string(), None)),
+        ParameterValue::List { .. } => Some(("aggregate value".to_string(), None)),
+        ParameterValue::Typed { type_name, .. } => {
+            Some((format!("typed value `{}`", type_name), None))
+        }
+        ParameterValue::Unknown { .. } => None,
+    }
+}
+
+struct ResolvedParameterValue {
+    value: String,
+    preview: Option<String>,
+    resolution_note: Option<String>,
+}
+
+fn extract_range_text(document: &Document, range: tower_lsp::lsp_types::Range) -> Option<&str> {
+    let start = offset_at_position(&document.text, range.start)?;
+    let end = offset_at_position(&document.text, range.end)?;
+    document.text.get(start..end)
+}
+
+fn offset_at_position(text: &str, position: tower_lsp::lsp_types::Position) -> Option<usize> {
+    let mut offset = 0usize;
+    let mut lines = text.split('\n');
+
+    for _ in 0..position.line {
+        let line = lines.next()?;
+        offset += line.len() + 1;
+    }
+
+    let line = lines.next()?;
+    let character = position.character as usize;
+    if character > line.len() {
+        return None;
+    }
+
+    Some(offset + character)
+}
+
+fn ifc_dimensions_for_si_unit(unit_name: &str) -> Option<[i32; 7]> {
+    Some(match unit_name {
+        "METRE" => [1, 0, 0, 0, 0, 0, 0],
+        "SQUARE_METRE" => [2, 0, 0, 0, 0, 0, 0],
+        "CUBIC_METRE" => [3, 0, 0, 0, 0, 0, 0],
+        "GRAM" => [0, 1, 0, 0, 0, 0, 0],
+        "SECOND" => [0, 0, 1, 0, 0, 0, 0],
+        "AMPERE" => [0, 0, 0, 1, 0, 0, 0],
+        "KELVIN" => [0, 0, 0, 0, 1, 0, 0],
+        "MOLE" => [0, 0, 0, 0, 0, 1, 0],
+        "CANDELA" => [0, 0, 0, 0, 0, 0, 1],
+        "RADIAN" => [0, 0, 0, 0, 0, 0, 0],
+        "STERADIAN" => [0, 0, 0, 0, 0, 0, 0],
+        "HERTZ" => [0, 0, -1, 0, 0, 0, 0],
+        "NEWTON" => [1, 1, -2, 0, 0, 0, 0],
+        "PASCAL" => [-1, 1, -2, 0, 0, 0, 0],
+        "JOULE" => [2, 1, -2, 0, 0, 0, 0],
+        "WATT" => [2, 1, -3, 0, 0, 0, 0],
+        "COULOMB" => [0, 0, 1, 1, 0, 0, 0],
+        "VOLT" => [2, 1, -3, -1, 0, 0, 0],
+        "FARAD" => [-2, -1, 4, 2, 0, 0, 0],
+        "OHM" => [2, 1, -3, -2, 0, 0, 0],
+        "SIEMENS" => [-2, -1, 3, 2, 0, 0, 0],
+        "WEBER" => [2, 1, -2, -1, 0, 0, 0],
+        "TESLA" => [0, 1, -2, -1, 0, 0, 0],
+        "HENRY" => [2, 1, -2, -2, 0, 0, 0],
+        "DEGREE_CELSIUS" => [0, 0, 0, 0, 1, 0, 0],
+        "LUMEN" => [0, 0, 0, 0, 0, 0, 1],
+        "LUX" => [-2, 0, 0, 0, 0, 0, 1],
+        "BECQUEREL" => [0, 0, -1, 0, 0, 0, 0],
+        "GRAY" => [2, 0, -2, 0, 0, 0, 0],
+        "SIEVERT" => [2, 0, -2, 0, 0, 0, 0],
+        _ => return None,
+    })
+}

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -1,0 +1,4 @@
+//! STEP-specific support code shared across language-server features.
+
+pub mod ast;
+pub mod derived;


### PR DESCRIPTION
  Add hover support for STEP * values used by derived IFC attributes. Should close #44.

  This PR adds targeted * hover handling for the two cases currently observed in our IFC
  samples and larger model set:
  - IFCSIUNIT
  - IFCGEOMETRICREPRESENTATIONSUBCONTEXT

  ## Code Additions
  - add hover handling for omitted_value (*) nodes
  - use the AST to find the respective text ranges
  - resolve IFCSIUNIT(*) to the derived Dimensions value using a fixed mapping (same as it is defined in EXPRESS)
  - resolve IFCGEOMETRICREPRESENTATIONSUBCONTEXT(*) values from ParentContext

  ## Refactoring
  - introduce src/step/ast.rs for STEP/tree-sitter context lookup
  - introduce src/step/derived.rs for STEP derived-value resolution