### PR TITLE
Add large-file support with on-demand and visible-range diagnostics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,8 @@ name = "ifc-language-server"
 version = "0.3.0"
 dependencies = [
  "espr",
+ "serde",
+ "serde_json",
  "sha2",
  "tokio",
  "tower-lsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 tree-sitter = "0.26"
 tree-sitter-ifc = "0.1.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [build-dependencies]
 sha2 = "0.10"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -6,19 +6,32 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use serde::Deserialize;
+use serde_json::Value;
 use tokio::sync::RwLock;
-use tower_lsp::jsonrpc::Result;
+use tower_lsp::jsonrpc::{Error as JsonRpcError, Result};
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 use tree_sitter::Parser;
 
 use crate::config::{ServerConfig, expand_schema_candidates, parse_server_config};
 use crate::diagnostics::datatype;
-use crate::document::Document;
+use crate::document::{Document, DocumentParseMetrics, DocumentParseMode};
 use crate::features::{definition, hover, references};
 use crate::schema::{
     SchemaDocCollection, inspect_local_schema_name, load_local_schema, normalize_name,
 };
+
+#[derive(Debug, Deserialize)]
+pub struct DiskDocumentParams {
+    pub uri: Url,
+}
+
+#[derive(Debug)]
+pub struct VisibleDiagnosticsParams {
+    pub uri: Url,
+    pub ranges: Vec<Range>,
+}
 
 #[derive(Debug, Default)]
 struct SchemaConfigState {
@@ -34,6 +47,8 @@ pub struct Backend {
     schema_docs: Arc<RwLock<SchemaDocCollection>>,
     schema_config: Arc<RwLock<SchemaConfigState>>,
 }
+
+const LARGE_FILE_DIAGNOSTICS_CAP_BYTES: usize = 50 * 1024 * 1024;
 
 impl Backend {
     pub fn new(client: Client) -> Self {
@@ -87,27 +102,95 @@ impl Backend {
         }
     }
 
-    async fn parse_document(&self, uri: &Url, text: String) -> Document {
+    async fn parse_document(
+        &self,
+        text: String,
+        mode: DocumentParseMode,
+    ) -> (Document, DocumentParseMetrics) {
         let mut parser = self.parser.write().await;
-        let document = Document::parse(&mut parser, text);
+        let result = Document::parse_with_metrics(&mut parser, text, mode);
         drop(parser);
-        let selected_schema_name = self.selected_schema_name(&document).await;
-        let diagnostics = if let Some(schema_name) = selected_schema_name.as_deref() {
-            let schema_docs = self.schema_docs.read().await;
-            schema_docs
-                .get(schema_name)
-                .map(|schema| {
-                    datatype::collect_with_schema_name(&document, schema, Some(schema_name))
-                })
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
+        result
+    }
+
+    async fn parse_document_with_diagnostics(&self, uri: &Url, text: String) -> Document {
+        // Buffer parses happen on every keystroke. Skip detailed parse-metrics
+        // logging here and emit only a one-line summary, and only for files
+        // large enough that the cost is interesting. Disk-loaded documents
+        // (`open_from_disk`) still get the full metrics log because they are
+        // the path where parse cost actually matters.
+        const SLOW_PARSE_LOG_THRESHOLD_BYTES: usize = 1024 * 1024;
+
+        let started = std::time::Instant::now();
+        let (document, metrics) = self.parse_document(text, DocumentParseMode::Full).await;
+
+        let diagnostics_started = std::time::Instant::now();
+        let diagnostics = self.collect_diagnostics(&document).await;
+        let diagnostics_ms = diagnostics_started.elapsed().as_millis();
 
         self.client
             .publish_diagnostics(uri.clone(), diagnostics, None)
             .await;
+
+        if metrics.source_bytes >= SLOW_PARSE_LOG_THRESHOLD_BYTES {
+            self.client
+                .log_message(
+                    MessageType::INFO,
+                    format!(
+                        "Document parsed: {} ({} bytes, total {}ms = parse {}ms + diagnostics {}ms)",
+                        uri,
+                        metrics.source_bytes,
+                        started.elapsed().as_millis(),
+                        metrics.total_parse_ms(),
+                        diagnostics_ms
+                    ),
+                )
+                .await;
+        }
         document
+    }
+
+    async fn log_parse_metrics(&self, label: &str, uri: &Url, metrics: &DocumentParseMetrics) {
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!(
+                    "{}: {} (mode={}, {} bytes, total {}ms = tree {}ms + schema {}ms + indexes {}ms; definitions={}, reference_groups={}, reference_ranges={}, instances={}, parameter_values={})",
+                    label,
+                    uri,
+                    metrics.mode.as_str(),
+                    metrics.source_bytes,
+                    metrics.total_parse_ms(),
+                    metrics.tree_parse_ms,
+                    metrics.schema_detect_ms,
+                    metrics.index_build_ms,
+                    metrics.definitions,
+                    metrics.reference_groups,
+                    metrics.reference_ranges,
+                    metrics.instances,
+                    metrics.parameter_values
+                ),
+            )
+            .await;
+    }
+
+    async fn collect_diagnostics(&self, document: &Document) -> Vec<Diagnostic> {
+        if document.parse_mode != DocumentParseMode::Full {
+            return Vec::new();
+        }
+
+        let selected_schema_name = self.selected_schema_name(document).await;
+        if let Some(schema_name) = selected_schema_name.as_deref() {
+            let schema_docs = self.schema_docs.read().await;
+            schema_docs
+                .get(schema_name)
+                .map(|schema| {
+                    datatype::collect_with_schema_name(document, schema, Some(schema_name))
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        }
     }
 
     async fn selected_schema_name(&self, document: &Document) -> Option<String> {
@@ -209,6 +292,307 @@ impl Backend {
         *self.schema_docs.write().await = schema_docs;
         *self.schema_config.write().await = next_state;
     }
+
+    pub async fn open_from_disk(&self, params: DiskDocumentParams) -> Result<()> {
+        let uri = params.uri;
+        let path = uri.to_file_path().map_err(|_| {
+            JsonRpcError::invalid_params(format!("uri is not a local file path: {}", uri))
+        })?;
+
+        let started = std::time::Instant::now();
+
+        let read_started = std::time::Instant::now();
+        let text = tokio::fs::read_to_string(&path).await.map_err(|e| {
+            let mut err = JsonRpcError::internal_error();
+            err.message = format!("failed to read {}: {}", path.display(), e).into();
+            err
+        })?;
+        let read_ms = read_started.elapsed().as_millis();
+        let bytes = text.len();
+        let mode = if bytes > LARGE_FILE_DIAGNOSTICS_CAP_BYTES {
+            DocumentParseMode::NavigationOnly
+        } else {
+            DocumentParseMode::Full
+        };
+
+        let (document, metrics) = self.parse_document(text, mode).await;
+        self.log_parse_metrics("Disk document parse", &uri, &metrics)
+            .await;
+
+        let schema_started = std::time::Instant::now();
+        self.check_schema_support(&document).await;
+        let schema_support_ms = schema_started.elapsed().as_millis();
+
+        let store_started = std::time::Instant::now();
+        self.store_document(document, &uri).await;
+        let store_ms = store_started.elapsed().as_millis();
+
+        let total_ms = started.elapsed().as_millis();
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!(
+                    "Document opened from disk: {} ({} bytes, total {}ms = read {}ms + parse {}ms + schema-check {}ms + store {}ms)",
+                    uri,
+                    bytes,
+                    total_ms,
+                    read_ms,
+                    metrics.total_parse_ms(),
+                    schema_support_ms,
+                    store_ms
+                ),
+            )
+            .await;
+        Ok(())
+    }
+
+    pub async fn close_from_disk(&self, params: DiskDocumentParams) -> Result<()> {
+        let uri = params.uri;
+        {
+            let mut documents = self.documents.write().await;
+            documents.remove(&uri);
+        }
+        self.client
+            .publish_diagnostics(uri.clone(), Vec::new(), None)
+            .await;
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!("Document closed from disk: {}", uri),
+            )
+            .await;
+        Ok(())
+    }
+
+    pub async fn diagnostics(&self, params: Value) -> Result<Vec<Diagnostic>> {
+        let uri = diagnostics_uri_from_value(&params)?;
+        let documents = self.documents.read().await;
+        let document = match documents.get(&uri) {
+            Some(document) => document,
+            None => return Ok(Vec::new()),
+        };
+
+        Ok(self.collect_diagnostics(document).await)
+    }
+
+    pub async fn visible_diagnostics(&self, params: Value) -> Result<Vec<Diagnostic>> {
+        const CONTEXT_LINES: u32 = 20;
+        const MAX_LINES_PER_RANGE: u32 = 500;
+
+        let params = visible_diagnostics_params_from_value(&params)?;
+        let documents = self.documents.read().await;
+        let source_document = match documents.get(&params.uri) {
+            Some(document) => document,
+            None => return Ok(Vec::new()),
+        };
+
+        let selected_schema_name = self.selected_schema_name(source_document).await;
+        let Some(schema_name) = selected_schema_name.as_deref() else {
+            return Ok(Vec::new());
+        };
+        let schema_docs = self.schema_docs.read().await;
+        let Some(schema) = schema_docs.get(schema_name) else {
+            return Ok(Vec::new());
+        };
+
+        let line_offsets = LineOffsets::from_text(&source_document.text);
+
+        let mut diagnostics = Vec::new();
+        for range in params.ranges {
+            let Some(slice) = visible_diagnostic_slice(
+                &source_document.text,
+                &line_offsets,
+                range,
+                CONTEXT_LINES,
+                MAX_LINES_PER_RANGE,
+            ) else {
+                continue;
+            };
+            let (slice_document, _metrics) = self
+                .parse_document(slice.text, DocumentParseMode::Full)
+                .await;
+            diagnostics.extend(
+                datatype::collect_visible_with_schema_name(
+                    &slice_document,
+                    source_document,
+                    schema,
+                    Some(schema_name),
+                )
+                .into_iter()
+                .map(|mut diagnostic| {
+                    shift_diagnostic_lines(&mut diagnostic, slice.start_line);
+                    diagnostic
+                }),
+            );
+        }
+        Ok(diagnostics)
+    }
+}
+
+struct VisibleDiagnosticSlice {
+    text: String,
+    start_line: u32,
+}
+
+/// Byte offsets of each line start in the source text, plus a terminator equal
+/// to `text.len()`. `line_offsets[i]` gives the byte index where line `i`
+/// begins, so a `[start_line, end_line]` line range maps to the byte slice
+/// `text[line_offsets[start_line]..line_offsets[end_line + 1]]`.
+///
+/// Building this once per `visible_diagnostics` call avoids re-scanning the
+/// whole document for every visible range when multiple editors view the same
+/// file.
+struct LineOffsets {
+    offsets: Vec<usize>,
+}
+
+impl LineOffsets {
+    fn from_text(text: &str) -> Self {
+        let mut offsets = Vec::with_capacity(text.len() / 64 + 1);
+        offsets.push(0);
+        for (index, byte) in text.bytes().enumerate() {
+            if byte == b'\n' {
+                offsets.push(index + 1);
+            }
+        }
+        if *offsets.last().expect("offsets always contains zero") != text.len() {
+            offsets.push(text.len());
+        }
+        Self { offsets }
+    }
+
+    fn line_count(&self) -> u32 {
+        // The last entry is the terminator (text length); subtract it.
+        (self.offsets.len().saturating_sub(1)) as u32
+    }
+
+    fn slice_bytes<'a>(&self, text: &'a str, start_line: u32, end_line: u32) -> Option<&'a str> {
+        let start = *self.offsets.get(start_line as usize)?;
+        let end_index = (end_line as usize + 1).min(self.offsets.len() - 1);
+        let end = self.offsets[end_index];
+        if start >= end {
+            return None;
+        }
+        Some(&text[start..end])
+    }
+}
+
+fn visible_diagnostic_slice(
+    text: &str,
+    line_offsets: &LineOffsets,
+    range: Range,
+    context_lines: u32,
+    max_lines_per_range: u32,
+) -> Option<VisibleDiagnosticSlice> {
+    let line_count = line_offsets.line_count();
+    if line_count == 0 {
+        return None;
+    }
+    let last_line = line_count.saturating_sub(1);
+
+    let visible_start = range.start.line.saturating_sub(context_lines).min(last_line);
+    let visible_end = range
+        .end
+        .line
+        .saturating_add(context_lines)
+        .min(visible_start.saturating_add(max_lines_per_range))
+        .min(last_line);
+
+    let slice = line_offsets.slice_bytes(text, visible_start, visible_end)?;
+
+    Some(VisibleDiagnosticSlice {
+        text: slice.to_string(),
+        start_line: visible_start,
+    })
+}
+
+fn shift_diagnostic_lines(diagnostic: &mut Diagnostic, line_offset: u32) {
+    diagnostic.range.start.line = diagnostic.range.start.line.saturating_add(line_offset);
+    diagnostic.range.end.line = diagnostic.range.end.line.saturating_add(line_offset);
+}
+
+// `ifc/diagnostics` is invoked from the VS Code extension's pull-diagnostics
+// path. We've seen the client send the URI in several shapes depending on how
+// the request was wired (raw string, `{ uri }` object, single-item array), so
+// the parser accepts all three rather than failing the request and losing the
+// diagnostics refresh.
+fn diagnostics_uri_from_value(value: &Value) -> Result<Url> {
+    match value {
+        Value::String(uri) => Url::parse(uri)
+            .map_err(|error| JsonRpcError::invalid_params(format!("invalid URI: {error}"))),
+        Value::Object(object) => object
+            .get("uri")
+            .ok_or_else(|| JsonRpcError::invalid_params("missing diagnostics URI"))
+            .and_then(diagnostics_uri_from_value),
+        Value::Array(items) => items
+            .first()
+            .ok_or_else(|| JsonRpcError::invalid_params("missing diagnostics URI"))
+            .and_then(diagnostics_uri_from_value),
+        _ => Err(JsonRpcError::invalid_params(
+            "diagnostics URI must be a string, { uri }, or single-item array",
+        )),
+    }
+}
+
+fn visible_diagnostics_params_from_value(value: &Value) -> Result<VisibleDiagnosticsParams> {
+    match value {
+        Value::Array(items) => items
+            .first()
+            .ok_or_else(|| JsonRpcError::invalid_params("missing visible diagnostics params"))
+            .and_then(visible_diagnostics_params_from_value),
+        Value::Object(object) => {
+            let uri = object
+                .get("uri")
+                .ok_or_else(|| JsonRpcError::invalid_params("missing visible diagnostics URI"))
+                .and_then(url_from_value)?;
+            let ranges = object
+                .get("ranges")
+                .ok_or_else(|| JsonRpcError::invalid_params("missing visible diagnostics ranges"))
+                .and_then(ranges_from_value)?;
+            Ok(VisibleDiagnosticsParams { uri, ranges })
+        }
+        _ => Err(JsonRpcError::invalid_params(
+            "visible diagnostics params must be { uri, ranges } or a single-item array",
+        )),
+    }
+}
+
+// The URI inside a custom-method payload must always be a plain string. If the
+// extension forgets `.toString()` on a `vscode.Uri`, its `toJSON()` serializes
+// as `{scheme, path, ...}` and corrupts the wire format — see
+// https://github.com/microsoft/vscode/issues/121198. We reject that shape
+// rather than absorb it so regressions surface at the call site.
+fn url_from_value(value: &Value) -> Result<Url> {
+    match value {
+        Value::String(uri) => Url::parse(uri)
+            .map_err(|error| JsonRpcError::invalid_params(format!("invalid URI: {error}"))),
+        Value::Object(_) => Err(JsonRpcError::invalid_params(
+            "URI must be a string; received a JSON object (likely a raw `vscode.Uri` \
+             that was not stringified before sending — call `.toString()` on the \
+             client side)",
+        )),
+        _ => Err(JsonRpcError::invalid_params(
+            "URI must be a string",
+        )),
+    }
+}
+
+fn ranges_from_value(value: &Value) -> Result<Vec<Range>> {
+    let Value::Array(items) = value else {
+        return Err(JsonRpcError::invalid_params(
+            "visible diagnostics ranges must be an array",
+        ));
+    };
+
+    items
+        .iter()
+        .cloned()
+        .map(|item| {
+            serde_json::from_value::<Range>(item).map_err(|error| {
+                JsonRpcError::invalid_params(format!("invalid visible diagnostics range: {error}"))
+            })
+        })
+        .collect()
 }
 
 #[tower_lsp::async_trait]
@@ -231,6 +615,9 @@ impl LanguageServer for Backend {
                 )),
                 definition_provider: Some(OneOf::Left(true)),
                 references_provider: Some(OneOf::Left(true)),
+                experimental: Some(serde_json::json!({
+                    "ifcLargeFileFeatures": true,
+                })),
                 ..Default::default()
             },
             ..Default::default()
@@ -269,7 +656,7 @@ impl LanguageServer for Backend {
             .log_message(MessageType::INFO, format!("Document opened: {}", uri))
             .await;
 
-        let document = self.parse_document(&uri, text).await;
+        let document = self.parse_document_with_diagnostics(&uri, text).await;
         self.check_schema_support(&document).await;
         self.store_document(document, &uri).await;
     }
@@ -277,7 +664,9 @@ impl LanguageServer for Backend {
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
         if let Some(change) = params.content_changes.into_iter().next() {
-            let document = self.parse_document(&uri, change.text).await;
+            let document = self
+                .parse_document_with_diagnostics(&uri, change.text)
+                .await;
             self.check_schema_support(&document).await;
             self.store_document(document, &uri).await;
         }
@@ -294,18 +683,6 @@ impl LanguageServer for Backend {
             None => return Ok(None),
         };
 
-        if let Some(node) = document.node_at_position(position) {
-            self.client
-                .log_message(
-                    MessageType::INFO,
-                    format!(
-                        "Node at cursor: kind={}, text={}",
-                        node.kind(),
-                        node.utf8_text(document.text.as_bytes()).unwrap_or("?")
-                    ),
-                )
-                .await;
-        }
         let schema_docs = self.schema_docs.read().await;
 
         Ok(hover::hover(
@@ -343,5 +720,178 @@ impl LanguageServer for Backend {
         };
 
         Ok(references::find_references(&uri, document, position))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const URI: &str = "file:///example.ifc";
+
+    #[test]
+    fn diagnostics_uri_accepts_bare_string() {
+        let value = Value::String(URI.into());
+        let uri = diagnostics_uri_from_value(&value).expect("parse string");
+        assert_eq!(uri.as_str(), URI);
+    }
+
+    #[test]
+    fn diagnostics_uri_accepts_object_with_uri_field() {
+        let value = serde_json::json!({ "uri": URI });
+        let uri = diagnostics_uri_from_value(&value).expect("parse object");
+        assert_eq!(uri.as_str(), URI);
+    }
+
+    #[test]
+    fn diagnostics_uri_accepts_single_item_array() {
+        let value = serde_json::json!([URI]);
+        let uri = diagnostics_uri_from_value(&value).expect("parse array");
+        assert_eq!(uri.as_str(), URI);
+    }
+
+    #[test]
+    fn diagnostics_uri_accepts_array_of_object() {
+        let value = serde_json::json!([{ "uri": URI }]);
+        let uri = diagnostics_uri_from_value(&value).expect("parse array of object");
+        assert_eq!(uri.as_str(), URI);
+    }
+
+    #[test]
+    fn diagnostics_uri_rejects_empty_array() {
+        let value = serde_json::json!([]);
+        assert!(diagnostics_uri_from_value(&value).is_err());
+    }
+
+    #[test]
+    fn diagnostics_uri_rejects_object_without_uri() {
+        let value = serde_json::json!({ "other": URI });
+        assert!(diagnostics_uri_from_value(&value).is_err());
+    }
+
+    #[test]
+    fn diagnostics_uri_rejects_non_url_string() {
+        let value = Value::String("not a url".into());
+        assert!(diagnostics_uri_from_value(&value).is_err());
+    }
+
+    #[test]
+    fn diagnostics_uri_rejects_unsupported_type() {
+        let value = serde_json::json!(42);
+        assert!(diagnostics_uri_from_value(&value).is_err());
+    }
+
+    #[test]
+    fn url_from_value_accepts_plain_string() {
+        let value = Value::String(URI.into());
+        let uri = url_from_value(&value).expect("parse string");
+        assert_eq!(uri.as_str(), URI);
+    }
+
+    #[test]
+    fn url_from_value_rejects_vscode_uri_tojson_form() {
+        let value = serde_json::json!({
+            "$mid": 1,
+            "scheme": "file",
+            "path": "/example.ifc"
+        });
+        let err = url_from_value(&value).expect_err("must reject map form");
+        assert!(
+            err.message.contains("vscode.Uri") || err.message.contains("toString"),
+            "error should hint at the client-side fix: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn visible_diagnostics_params_round_trip_named_object() {
+        let value = serde_json::json!({
+            "uri": "file:///example.ifc",
+            "ranges": [
+                {
+                    "start": { "line": 10, "character": 0 },
+                    "end": { "line": 12, "character": 3 }
+                }
+            ]
+        });
+        let params = visible_diagnostics_params_from_value(&value).expect("parse params");
+        assert_eq!(params.uri.scheme(), "file");
+        assert_eq!(params.ranges.len(), 1);
+        assert_eq!(params.ranges[0].start.line, 10);
+    }
+
+    #[test]
+    fn visible_diagnostics_params_reject_vscode_uri_object() {
+        let value = serde_json::json!({
+            "uri": {
+                "$mid": 1,
+                "scheme": "file",
+                "path": "/example.ifc"
+            },
+            "ranges": []
+        });
+        assert!(visible_diagnostics_params_from_value(&value).is_err());
+    }
+
+    #[test]
+    fn line_offsets_indexes_each_line_start() {
+        let text = "a\nbb\nccc\n";
+        let offsets = LineOffsets::from_text(text);
+        // line_count counts content lines (between starts); trailing terminator
+        // is the byte length of the text.
+        assert_eq!(offsets.line_count(), 3);
+        assert_eq!(offsets.slice_bytes(text, 0, 0), Some("a\n"));
+        assert_eq!(offsets.slice_bytes(text, 1, 1), Some("bb\n"));
+        assert_eq!(offsets.slice_bytes(text, 0, 2), Some("a\nbb\nccc\n"));
+    }
+
+    #[test]
+    fn line_offsets_handles_text_without_trailing_newline() {
+        let text = "a\nbb";
+        let offsets = LineOffsets::from_text(text);
+        assert_eq!(offsets.line_count(), 2);
+        assert_eq!(offsets.slice_bytes(text, 0, 1), Some("a\nbb"));
+    }
+
+    #[test]
+    fn visible_diagnostic_slice_extracts_window_with_context() {
+        let text = "L0\nL1\nL2\nL3\nL4\nL5\n";
+        let offsets = LineOffsets::from_text(text);
+        let range = Range {
+            start: Position {
+                line: 2,
+                character: 0,
+            },
+            end: Position {
+                line: 3,
+                character: 0,
+            },
+        };
+        let slice = visible_diagnostic_slice(text, &offsets, range, 1, 100)
+            .expect("slice produces a window");
+        assert_eq!(slice.start_line, 1);
+        assert_eq!(slice.text, "L1\nL2\nL3\nL4\n");
+    }
+
+    #[test]
+    fn visible_diagnostic_slice_caps_window_to_max_lines() {
+        let text = "a\n".repeat(50);
+        let offsets = LineOffsets::from_text(&text);
+        let range = Range {
+            start: Position {
+                line: 5,
+                character: 0,
+            },
+            end: Position {
+                line: 45,
+                character: 0,
+            },
+        };
+        let slice = visible_diagnostic_slice(&text, &offsets, range, 0, 10)
+            .expect("slice produces a window");
+        // `max_lines_per_range` clamps the visible end relative to the start.
+        assert_eq!(slice.start_line, 5);
+        // Slice should cover lines 5..=15 inclusive (11 lines = max + 1).
+        assert_eq!(slice.text.lines().count(), 11);
     }
 }

--- a/src/diagnostics/datatype.rs
+++ b/src/diagnostics/datatype.rs
@@ -3,7 +3,8 @@
 //! reports arity, reference, primitive, aggregate, enumeration, and select-type mismatches.
 //! General EXPRESS `WHERE` rules are intentionally out of scope for the current implementation.
 
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Range};
+use tree_sitter::Node;
 
 use crate::document::{Document, EntityInstanceInfo, ParameterValue};
 use crate::schema::{
@@ -16,6 +17,42 @@ pub fn collect_with_schema_name(
     schema: &SchemaDoc,
     schema_name: Option<&str>,
 ) -> Vec<Diagnostic> {
+    collect_with_options(
+        document,
+        schema,
+        schema_name,
+        DiagnosticOptions {
+            reference_document: None,
+        },
+    )
+}
+
+pub fn collect_visible_with_schema_name(
+    document: &Document,
+    reference_document: &Document,
+    schema: &SchemaDoc,
+    schema_name: Option<&str>,
+) -> Vec<Diagnostic> {
+    collect_with_options(
+        document,
+        schema,
+        schema_name,
+        DiagnosticOptions {
+            reference_document: Some(reference_document),
+        },
+    )
+}
+
+struct DiagnosticOptions<'a> {
+    reference_document: Option<&'a Document>,
+}
+
+fn collect_with_options(
+    document: &Document,
+    schema: &SchemaDoc,
+    schema_name: Option<&str>,
+    options: DiagnosticOptions<'_>,
+) -> Vec<Diagnostic> {
     let mut diagnostics = collect_syntax_diagnostics(document);
 
     for instance in &document.instances {
@@ -24,7 +61,14 @@ pub fn collect_with_schema_name(
             continue;
         };
 
-        validate_instance(document, schema, entity, instance, &mut diagnostics);
+        validate_instance(
+            document,
+            schema,
+            entity,
+            instance,
+            &mut diagnostics,
+            &options,
+        );
     }
 
     diagnostics
@@ -36,6 +80,7 @@ fn validate_instance(
     entity: &EntityDoc,
     instance: &EntityInstanceInfo,
     diagnostics: &mut Vec<Diagnostic>,
+    options: &DiagnosticOptions<'_>,
 ) {
     if instance.parameters.len() != entity.attributes.len() {
         diagnostics.push(Diagnostic {
@@ -54,7 +99,7 @@ fn validate_instance(
     }
 
     for (value, attribute) in instance.parameters.iter().zip(&entity.attributes) {
-        if let Some(message) = validate_value(document, schema, value, attribute) {
+        if let Some(message) = validate_value(document, schema, value, attribute, options) {
             diagnostics.push(Diagnostic {
                 range: value.range(),
                 severity: Some(DiagnosticSeverity::ERROR),
@@ -89,6 +134,7 @@ fn validate_value(
     schema: &SchemaDoc,
     value: &ParameterValue,
     attribute: &EntityAttributeDoc,
+    options: &DiagnosticOptions<'_>,
 ) -> Option<String> {
     match value {
         ParameterValue::Null { .. } => {
@@ -105,7 +151,7 @@ fn validate_value(
                 Some("`*` is not supported for this attribute".to_string())
             }
         }
-        _ => validate_non_null_value(document, schema, value, &attribute.ty),
+        _ => validate_non_null_value(document, schema, value, &attribute.ty, options),
     }
 }
 
@@ -114,17 +160,20 @@ fn validate_non_null_value(
     schema: &SchemaDoc,
     value: &ParameterValue,
     expected: &TypeRef,
+    options: &DiagnosticOptions<'_>,
 ) -> Option<String> {
     match expected {
         TypeRef::Primitive(primitive) => validate_primitive(value, primitive),
-        TypeRef::Aggregate(aggregate) => validate_aggregate(document, schema, value, aggregate),
+        TypeRef::Aggregate(aggregate) => {
+            validate_aggregate(document, schema, value, aggregate, options)
+        }
         TypeRef::GenericEntity { .. } | TypeRef::Generic { .. } => None,
         TypeRef::Named(named) => match named.kind {
             NamedTypeKind::Entity => {
-                validate_entity_reference(document, schema, value, &named.name)
+                validate_entity_reference(document, schema, value, &named.name, options)
             }
             NamedTypeKind::Type | NamedTypeKind::Unresolved => {
-                validate_named_type(document, schema, value, &named.name)
+                validate_named_type(document, schema, value, &named.name, options)
             }
         },
     }
@@ -135,6 +184,7 @@ fn validate_named_type(
     schema: &SchemaDoc,
     value: &ParameterValue,
     type_name: &str,
+    options: &DiagnosticOptions<'_>,
 ) -> Option<String> {
     let type_def = schema.type_decl(type_name)?;
     match type_def {
@@ -158,10 +208,10 @@ fn validate_named_type(
                         type_name
                     ))
                 } else {
-                    validate_non_null_value(document, schema, &inner[0], &alias.target)
+                    validate_non_null_value(document, schema, &inner[0], &alias.target, options)
                 }
             } else {
-                validate_non_null_value(document, schema, value, &alias.target)
+                validate_non_null_value(document, schema, value, &alias.target, options)
             }
         }
         TypeDoc::Enumeration(enum_def) => {
@@ -190,7 +240,7 @@ fn validate_named_type(
                 validate_enum_value(value, &enum_def.items)
             }
         }
-        TypeDoc::Select(select) => validate_select(document, schema, value, select),
+        TypeDoc::Select(select) => validate_select(document, schema, value, select, options),
     }
 }
 
@@ -199,11 +249,12 @@ fn validate_select(
     schema: &SchemaDoc,
     value: &ParameterValue,
     select: &SelectTypeDef,
+    options: &DiagnosticOptions<'_>,
 ) -> Option<String> {
     if select
         .options
         .iter()
-        .any(|option| validate_non_null_value(document, schema, value, option).is_none())
+        .any(|option| validate_non_null_value(document, schema, value, option, options).is_none())
     {
         None
     } else {
@@ -238,6 +289,7 @@ fn validate_aggregate(
     schema: &SchemaDoc,
     value: &ParameterValue,
     aggregate: &AggregateTypeRef,
+    options: &DiagnosticOptions<'_>,
 ) -> Option<String> {
     let ParameterValue::List { items, .. } = value else {
         return Some(format!(
@@ -269,7 +321,9 @@ fn validate_aggregate(
     }
 
     for item in items {
-        if let Some(message) = validate_non_null_value(document, schema, item, &aggregate.item) {
+        if let Some(message) =
+            validate_non_null_value(document, schema, item, &aggregate.item, options)
+        {
             return Some(message);
         }
     }
@@ -282,6 +336,7 @@ fn validate_entity_reference(
     schema: &SchemaDoc,
     value: &ParameterValue,
     expected_entity: &str,
+    options: &DiagnosticOptions<'_>,
 ) -> Option<String> {
     let ParameterValue::Reference { id, .. } = value else {
         return Some(format!(
@@ -291,21 +346,51 @@ fn validate_entity_reference(
         ));
     };
 
-    let Some(definition) = document.definitions.get(id) else {
+    let reference_document = options.reference_document.unwrap_or(document);
+    let Some(definition) = reference_document.definitions.get(id) else {
         return Some(format!(
             "reference `#{}` does not resolve to a local entity",
             id
         ));
     };
 
-    if schema.is_entity_compatible(&definition.entity_name, expected_entity) {
+    let entity_name = definition
+        .entity_name
+        .as_deref()
+        .map(str::to_string)
+        .or_else(|| lazy_definition_entity_name(reference_document, definition.entity_range));
+    let Some(entity_name) = entity_name.as_deref() else {
+        return Some(format!(
+            "reference `#{}` does not have entity type information",
+            id
+        ));
+    };
+
+    if schema.is_entity_compatible(entity_name, expected_entity) {
         None
     } else {
         Some(format!(
             "expected reference to `{}` but `#{}` points to `{}`",
-            expected_entity, id, definition.entity_name
+            expected_entity, id, entity_name
         ))
     }
+}
+
+fn lazy_definition_entity_name(document: &Document, range: Range) -> Option<String> {
+    let mut node = document.node_at_position(range.start)?;
+    while node.kind() != "entity_instance" {
+        node = node.parent()?;
+    }
+
+    entity_name_child(node, &document.text)
+}
+
+fn entity_name_child(node: Node<'_>, text: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|child| child.kind() == "entity_name")
+        .and_then(|child| child.utf8_text(text.as_bytes()).ok())
+        .map(str::to_ascii_uppercase)
 }
 
 fn validate_primitive(value: &ParameterValue, primitive: &PrimitiveType) -> Option<String> {
@@ -492,6 +577,7 @@ mod tests {
             text: "#1=IFCWALL('gid',.MOVABLE.);".to_string(),
             tree: None,
             schema_name: None,
+            parse_mode: crate::document::DocumentParseMode::Full,
             definitions: HashMap::new(),
             references: HashMap::new(),
             instances: vec![crate::document::EntityInstanceInfo {

--- a/src/document.rs
+++ b/src/document.rs
@@ -4,6 +4,7 @@
 //! It also stores structured parameter values so diagnostics can validate attribute arguments.
 
 use std::collections::HashMap;
+use std::time::Instant;
 
 use tower_lsp::lsp_types::{Position, Range};
 use tree_sitter::{Node, Parser, Point, Tree, TreeCursor};
@@ -13,17 +14,61 @@ pub struct Document {
     pub text: String,
     pub tree: Option<Tree>,
     pub schema_name: Option<String>,
+    pub parse_mode: DocumentParseMode,
     pub definitions: HashMap<u32, DefinitionInfo>,
     pub references: HashMap<u32, Vec<Range>>,
     pub instances: Vec<EntityInstanceInfo>,
     pub(crate) instance_indexes_by_id: HashMap<u32, usize>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DocumentParseMode {
+    Full,
+    NavigationOnly,
+}
+
+impl DocumentParseMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::NavigationOnly => "navigation-only",
+        }
+    }
+
+    fn should_parse_parameters(self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    fn should_index_references(self) -> bool {
+        matches!(self, Self::Full)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DocumentParseMetrics {
+    pub mode: DocumentParseMode,
+    pub source_bytes: usize,
+    pub tree_parse_ms: u128,
+    pub schema_detect_ms: u128,
+    pub index_build_ms: u128,
+    pub definitions: usize,
+    pub reference_groups: usize,
+    pub reference_ranges: usize,
+    pub instances: usize,
+    pub parameter_values: usize,
+}
+
+impl DocumentParseMetrics {
+    pub fn total_parse_ms(&self) -> u128 {
+        self.tree_parse_ms + self.schema_detect_ms + self.index_build_ms
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DefinitionInfo {
     pub id_range: Range,
     pub entity_range: Range,
-    pub entity_name: String,
+    pub entity_name: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -111,24 +156,65 @@ impl ParameterValue {
 }
 
 impl Document {
+    #[cfg(test)]
     pub fn parse(parser: &mut Parser, text: String) -> Self {
+        Self::parse_with_metrics(parser, text, DocumentParseMode::Full).0
+    }
+
+    pub fn parse_with_metrics(
+        parser: &mut Parser,
+        text: String,
+        mode: DocumentParseMode,
+    ) -> (Self, DocumentParseMetrics) {
+        let source_bytes = text.len();
+
+        let tree_started = Instant::now();
         let tree = parser.parse(&text, None);
+        let tree_parse_ms = tree_started.elapsed().as_millis();
+
+        let schema_started = Instant::now();
         let schema_name = detect_schema(&tree, &text);
-        let (definitions, references, instances) = build_indexes(&tree, &text);
+        let schema_detect_ms = schema_started.elapsed().as_millis();
+
+        let index_started = Instant::now();
+        let (definitions, references, instances) = build_indexes(&tree, &text, mode);
+        let index_build_ms = index_started.elapsed().as_millis();
+
+        let reference_ranges = references.values().map(Vec::len).sum();
+        let parameter_values = instances
+            .iter()
+            .map(|instance| count_parameter_values(&instance.parameters))
+            .sum();
+        let metrics = DocumentParseMetrics {
+            mode,
+            source_bytes,
+            tree_parse_ms,
+            schema_detect_ms,
+            index_build_ms,
+            definitions: definitions.len(),
+            reference_groups: references.len(),
+            reference_ranges,
+            instances: instances.len(),
+            parameter_values,
+        };
+
         let instance_indexes_by_id = instances
             .iter()
             .enumerate()
             .filter_map(|(index, instance)| instance.id.map(|id| (id, index)))
             .collect();
-        Self {
+        let document = Self {
             text,
             tree,
             schema_name,
+            parse_mode: mode,
             definitions,
             references,
             instances,
             instance_indexes_by_id,
-        }
+        };
+
+        (document, metrics)
     }
 
     pub fn node_at_position(&self, position: Position) -> Option<Node<'_>> {
@@ -146,6 +232,17 @@ impl Document {
             .get(&id)
             .and_then(|index| self.instances.get(*index))
     }
+}
+
+fn count_parameter_values(parameters: &[ParameterValue]) -> usize {
+    parameters
+        .iter()
+        .map(|parameter| match parameter {
+            ParameterValue::List { items, .. } => 1 + count_parameter_values(items),
+            ParameterValue::Typed { inner, .. } => 1 + count_parameter_values(inner),
+            _ => 1,
+        })
+        .sum()
 }
 
 fn detect_schema(tree: &Option<Tree>, text: &str) -> Option<String> {
@@ -222,7 +319,7 @@ fn extract_first_string(node: Node<'_>, text: &str) -> Option<String> {
     None
 }
 
-fn build_indexes(tree: &Option<Tree>, text: &str) -> DocumentIndexes {
+fn build_indexes(tree: &Option<Tree>, text: &str, mode: DocumentParseMode) -> DocumentIndexes {
     let mut definitions = HashMap::new();
     let mut references = HashMap::new();
     let mut instances = Vec::new();
@@ -236,6 +333,7 @@ fn build_indexes(tree: &Option<Tree>, text: &str) -> DocumentIndexes {
     traverse(
         &mut cursor,
         text,
+        mode,
         &mut definitions,
         &mut references,
         &mut instances,
@@ -247,6 +345,7 @@ fn build_indexes(tree: &Option<Tree>, text: &str) -> DocumentIndexes {
 fn traverse(
     cursor: &mut TreeCursor,
     text: &str,
+    mode: DocumentParseMode,
     definitions: &mut HashMap<u32, DefinitionInfo>,
     references: &mut HashMap<u32, Vec<Range>>,
     instances: &mut Vec<EntityInstanceInfo>,
@@ -255,7 +354,7 @@ fn traverse(
         let node = cursor.node();
 
         if node.kind() == "entity_instance" {
-            if let Some(instance) = parse_entity_instance(node, text) {
+            if let Some(instance) = parse_entity_instance(node, text, mode) {
                 if let Some(id) = instance.id {
                     definitions.insert(
                         id,
@@ -264,13 +363,18 @@ fn traverse(
                                 .id_range
                                 .expect("definition ids should have a range"),
                             entity_range: instance.entity_range,
-                            entity_name: instance.entity_name.clone(),
+                            entity_name: mode
+                                .should_parse_parameters()
+                                .then(|| instance.entity_name.clone()),
                         },
                     );
                 }
-                instances.push(instance);
+                if mode.should_parse_parameters() {
+                    instances.push(instance);
+                }
             }
-        } else if node.kind() == "reference"
+        } else if mode.should_index_references()
+            && node.kind() == "reference"
             && let Ok(ref_text) = node.utf8_text(text.as_bytes())
             && let Ok(id) = ref_text.trim_start_matches('#').parse::<u32>()
         {
@@ -278,7 +382,7 @@ fn traverse(
         }
 
         if cursor.goto_first_child() {
-            traverse(cursor, text, definitions, references, instances);
+            traverse(cursor, text, mode, definitions, references, instances);
             cursor.goto_parent();
         }
 
@@ -288,7 +392,11 @@ fn traverse(
     }
 }
 
-fn parse_entity_instance(node: Node<'_>, text: &str) -> Option<EntityInstanceInfo> {
+fn parse_entity_instance(
+    node: Node<'_>,
+    text: &str,
+    mode: DocumentParseMode,
+) -> Option<EntityInstanceInfo> {
     let mut child_cursor = node.walk();
     let mut id = None;
     let mut id_range = None;
@@ -311,7 +419,9 @@ fn parse_entity_instance(node: Node<'_>, text: &str) -> Option<EntityInstanceInf
             }
             "parameter_list" => {
                 parameter_list_range = Some(node_range(&child));
-                parameters = parse_parameter_list(child, text);
+                if mode.should_parse_parameters() {
+                    parameters = parse_parameter_list(child, text);
+                }
             }
             _ => {}
         }
@@ -533,6 +643,10 @@ mod tests {
         let document = parse_document(text);
         assert!(document.definitions.contains_key(&1));
         assert!(document.references.is_empty());
+        assert_eq!(
+            document.definitions[&1].entity_name.as_deref(),
+            Some("IFCWALL")
+        );
         // "#1" starts at column 0, row 0 and ends at column 2, row 0
         assert_eq!(
             document.definitions[&1].id_range,
@@ -586,5 +700,31 @@ mod tests {
         let instance = document.instance_by_id(2).expect("instance should exist");
 
         assert_eq!(instance.entity_name, "IFCDOOR");
+    }
+
+    #[test]
+    fn navigation_only_parse_skips_full_instances() {
+        let text = "#1=IFCWALL(#2);\n#2=IFCDOOR($);";
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_ifc::LANGUAGE.into())
+            .expect("Error loading IFC parser");
+
+        let (document, metrics) = Document::parse_with_metrics(
+            &mut parser,
+            text.to_string(),
+            DocumentParseMode::NavigationOnly,
+        );
+
+        assert_eq!(document.parse_mode, DocumentParseMode::NavigationOnly);
+        assert_eq!(document.definitions.len(), 2);
+        assert!(document.references.is_empty());
+        assert!(document.instances.is_empty());
+        assert!(document.instance_indexes_by_id.is_empty());
+        assert_eq!(document.definitions[&1].entity_name, None);
+        assert_eq!(metrics.reference_groups, 0);
+        assert_eq!(metrics.reference_ranges, 0);
+        assert_eq!(metrics.instances, 0);
+        assert_eq!(metrics.parameter_values, 0);
     }
 }

--- a/src/features/hover.rs
+++ b/src/features/hover.rs
@@ -504,6 +504,7 @@ mod tests {
             text: "#1=IFCWALL($);".to_string(),
             tree: None,
             schema_name: None,
+            parse_mode: crate::document::DocumentParseMode::Full,
             definitions: HashMap::new(),
             references: HashMap::new(),
             instances: Vec::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,12 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::new(Backend::new);
+    let (service, socket) = LspService::build(Backend::new)
+        .custom_method("ifc/openFromDisk", Backend::open_from_disk)
+        .custom_method("ifc/closeFromDisk", Backend::close_from_disk)
+        .custom_method("ifc/diagnostics", Backend::diagnostics)
+        .custom_method("ifc/visibleDiagnostics", Backend::visible_diagnostics)
+        .finish();
 
     Server::new(stdin, stdout, socket).serve(service).await;
 }


### PR DESCRIPTION
Large IFC files (>50 MiB) can now be opened from disk through new custom LSP methods without blocking the editor on every keystroke. To keep these files responsive, parsing runs in a lighter "navigation-only" mode: go-to-definition still works, but the full reference index, parameter parsing, and whole-file diagnostics are skipped. Find-all-references is unavailable, and diagnostics are instead computed on demand for the visible viewport only. Smaller files keep the existing behavior with full indexing and diagnostics on every change.