### PR TITLE
Document memory layout

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,10 +23,8 @@ const SCHEMAS: &[(&str, &str, &str)] = &[
     ),
 ];
 
-const IFC2X3_ENTITY_INDEX: (&str, &str) = (
-    "https://standards.buildingsmart.org/IFC/RELEASE/IFC2x3/TC1/HTML/alphabeticalorder_entities.htm",
-    "8e395ea92e81c7b2c003291671bf96ee75b38e9d321ea4a58f5f4d6ee782e4cb",
-);
+const IFC2X3_ENTITY_INDEX_URL: &str =
+    "https://standards.buildingsmart.org/IFC/RELEASE/IFC2x3/TC1/HTML/alphabeticalorder_entities.htm";
 const IFC2X3_ENTITY_COUNT: usize = 653;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -51,18 +49,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         fs::write(express_dir.join(file_name), source)?;
     }
 
-    let entity_index = ureq::get(IFC2X3_ENTITY_INDEX.0)
+    let entity_index = ureq::get(IFC2X3_ENTITY_INDEX_URL)
         .call()?
         .body_mut()
         .read_to_vec()?;
-    let actual_sha256 = format!("{:x}", Sha256::digest(&entity_index));
-    if actual_sha256 != IFC2X3_ENTITY_INDEX.1 {
-        return Err(format!(
-            "checksum mismatch for IFC2x3 entity index: expected {}, got {}",
-            IFC2X3_ENTITY_INDEX.1, actual_sha256
-        )
-        .into());
-    }
 
     let entity_index = String::from_utf8(entity_index)?;
     let links = parse_ifc2x3_entity_links(&entity_index)?;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -51,11 +51,6 @@ impl Backend {
         }
     }
 
-    async fn store_document(&self, document: Document, uri: &Url) {
-        let mut documents = self.documents.write().await;
-        documents.insert(uri.clone(), document);
-    }
-
     async fn check_schema_support(&self, document: &Document) {
         let forced_schema_name = self.schema_config.read().await.forced_schema_name.clone();
 
@@ -87,12 +82,9 @@ impl Backend {
         }
     }
 
-    async fn parse_document(&self, uri: &Url, text: String) -> Document {
-        let mut parser = self.parser.write().await;
-        let document = Document::parse(&mut parser, text);
-        drop(parser);
+    async fn collect_diagnostics(&self, document: &Document) -> Vec<Diagnostic> {
         let selected_schema_name = self.selected_schema_name(&document).await;
-        let diagnostics = if let Some(schema_name) = selected_schema_name.as_deref() {
+        if let Some(schema_name) = selected_schema_name.as_deref() {
             let schema_docs = self.schema_docs.read().await;
             schema_docs
                 .get(schema_name)
@@ -102,12 +94,70 @@ impl Backend {
                 .unwrap_or_default()
         } else {
             Vec::new()
-        };
+        }
+    }
 
+    async fn publish_document_diagnostics(&self, uri: &Url, diagnostics: Vec<Diagnostic>) {
         self.client
             .publish_diagnostics(uri.clone(), diagnostics, None)
             .await;
-        document
+    }
+
+    async fn load_text_as_active_document(&self, uri: &Url, text: String) -> Vec<Diagnostic> {
+        let mut documents = self.documents.write().await;
+        for (document_uri, document) in documents.iter_mut() {
+            if document_uri != uri {
+                document.unload_parse_state();
+            }
+        }
+
+        let document = documents
+            .entry(uri.clone())
+            .or_insert_with(|| Document::new_unloaded(String::new()));
+        document.unload_parse_state();
+        document.text = text;
+
+        {
+            let mut parser = self.parser.write().await;
+            document.reload_parse_state(&mut parser);
+        }
+
+        self.check_schema_support(document).await;
+        self.collect_diagnostics(document).await
+    }
+
+    async fn ensure_document_loaded(
+        &self,
+        documents: &mut HashMap<Url, Document>,
+        uri: &Url,
+    ) -> Option<Option<Vec<Diagnostic>>> {
+        if documents.get(uri)?.is_parse_state_loaded() {
+            return Some(None);
+        }
+
+        for (document_uri, document) in documents.iter_mut() {
+            if document_uri != uri {
+                document.unload_parse_state();
+            }
+        }
+
+        {
+            let mut parser = self.parser.write().await;
+            documents.get_mut(uri)?.reload_parse_state(&mut parser);
+        }
+
+        let diagnostics = {
+            let document = documents.get(uri)?;
+            self.collect_diagnostics(document).await
+        };
+
+        Some(Some(diagnostics))
+    }
+
+    async fn request_time_diagnostics(&self, diagnostics: Option<Vec<Diagnostic>>, uri: &Url) {
+        if let Some(diagnostics) = diagnostics {
+            self.publish_document_diagnostics(uri, diagnostics).await;
+        }
     }
 
     async fn selected_schema_name(&self, document: &Document) -> Option<String> {
@@ -269,18 +319,26 @@ impl LanguageServer for Backend {
             .log_message(MessageType::INFO, format!("Document opened: {}", uri))
             .await;
 
-        let document = self.parse_document(&uri, text).await;
-        self.check_schema_support(&document).await;
-        self.store_document(document, &uri).await;
+        let diagnostics = self.load_text_as_active_document(&uri, text).await;
+        self.publish_document_diagnostics(&uri, diagnostics).await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
         if let Some(change) = params.content_changes.into_iter().next() {
-            let document = self.parse_document(&uri, change.text).await;
-            self.check_schema_support(&document).await;
-            self.store_document(document, &uri).await;
+            let diagnostics = self.load_text_as_active_document(&uri, change.text).await;
+            self.publish_document_diagnostics(&uri, diagnostics).await;
         }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let uri = params.text_document.uri;
+
+        let mut documents = self.documents.write().await;
+        documents.remove(&uri);
+        drop(documents);
+
+        self.client.publish_diagnostics(uri, Vec::new(), None).await;
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
@@ -288,32 +346,40 @@ impl LanguageServer for Backend {
         let position = params.text_document_position_params.position;
         let forced_schema_name = self.schema_config.read().await.forced_schema_name.clone();
 
-        let documents = self.documents.read().await;
+        let mut documents = self.documents.write().await;
+        let diagnostics = match self.ensure_document_loaded(&mut documents, &uri).await {
+            Some(diagnostics) => diagnostics,
+            None => return Ok(None),
+        };
         let document = match documents.get(&uri) {
             Some(document) => document,
             None => return Ok(None),
         };
 
-        if let Some(node) = document.node_at_position(position) {
-            self.client
-                .log_message(
-                    MessageType::INFO,
-                    format!(
-                        "Node at cursor: kind={}, text={}",
-                        node.kind(),
-                        node.utf8_text(document.text.as_bytes()).unwrap_or("?")
-                    ),
-                )
-                .await;
-        }
+        let node_message = document.node_at_position(position).map(|node| {
+            format!(
+                "Node at cursor: kind={}, text={}",
+                node.kind(),
+                node.utf8_text(document.text.as_bytes()).unwrap_or("?")
+            )
+        });
         let schema_docs = self.schema_docs.read().await;
 
-        Ok(hover::hover(
+        let result = hover::hover(
             document,
             position,
             &schema_docs,
             forced_schema_name.as_deref(),
-        ))
+        );
+        drop(schema_docs);
+        drop(documents);
+
+        if let Some(message) = node_message {
+            self.client.log_message(MessageType::INFO, message).await;
+        }
+        self.request_time_diagnostics(diagnostics, &uri).await;
+
+        Ok(result)
     }
 
     async fn goto_definition(
@@ -323,25 +389,43 @@ impl LanguageServer for Backend {
         let uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let documents = self.documents.read().await;
+        let mut documents = self.documents.write().await;
+        let diagnostics = match self.ensure_document_loaded(&mut documents, &uri).await {
+            Some(diagnostics) => diagnostics,
+            None => return Ok(None),
+        };
         let document = match documents.get(&uri) {
             Some(document) => document,
             None => return Ok(None),
         };
 
-        Ok(definition::goto_definition(&uri, document, position))
+        let result = definition::goto_definition(&uri, document, position);
+        drop(documents);
+
+        self.request_time_diagnostics(diagnostics, &uri).await;
+
+        Ok(result)
     }
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
         let uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
 
-        let documents = self.documents.read().await;
+        let mut documents = self.documents.write().await;
+        let diagnostics = match self.ensure_document_loaded(&mut documents, &uri).await {
+            Some(diagnostics) => diagnostics,
+            None => return Ok(None),
+        };
         let document = match documents.get(&uri) {
             Some(document) => document,
             None => return Ok(None),
         };
 
-        Ok(references::find_references(&uri, document, position))
+        let result = references::find_references(&uri, document, position);
+        drop(documents);
+
+        self.request_time_diagnostics(diagnostics, &uri).await;
+
+        Ok(result)
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -4,7 +4,6 @@
 //! Request handlers stay thin here and delegate document-specific work to the feature modules.
 
 use std::collections::HashMap;
-use std::process::Command;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -100,25 +99,20 @@ impl Backend {
         let mut documents = self.documents.write().await;
         for (document_uri, document) in documents.iter_mut() {
             if document_uri != uri {
-                log_document_memory("before unload", document_uri, document);
                 document.unload_parse_state();
-                log_document_memory("after unload", document_uri, document);
             }
         }
 
         let document = documents
             .entry(uri.clone())
             .or_insert_with(|| Document::new_unloaded(String::new()));
-        log_document_memory("before active text reload", uri, document);
         document.unload_parse_state();
         document.text = text;
-        log_document_memory("after active text replace", uri, document);
 
         {
             let mut parser = new_parser();
             document.reload_parse_state(&mut parser);
         }
-        log_document_memory("after active reload", uri, document);
 
         self.check_schema_support(document).await;
         self.collect_diagnostics(document).await
@@ -135,21 +129,13 @@ impl Backend {
 
         for (document_uri, document) in documents.iter_mut() {
             if document_uri != uri {
-                log_document_memory("before unload", document_uri, document);
                 document.unload_parse_state();
-                log_document_memory("after unload", document_uri, document);
             }
         }
 
         {
             let mut parser = new_parser();
-            if let Some(document) = documents.get(uri) {
-                log_document_memory("before request reload", uri, document);
-            }
             documents.get_mut(uri)?.reload_parse_state(&mut parser);
-        }
-        if let Some(document) = documents.get(uri) {
-            log_document_memory("after request reload", uri, document);
         }
 
         let diagnostics = {
@@ -275,35 +261,6 @@ fn new_parser() -> tree_sitter::Parser {
     parser
 }
 
-fn log_document_memory(event: &str, uri: &Url, document: &Document) {
-    eprintln!(
-        "[ifc-lsp memory] {} uri={} rss_kib={} {}",
-        event,
-        uri,
-        process_rss_kib()
-            .map(|rss| rss.to_string())
-            .unwrap_or_else(|| "unknown".to_string()),
-        document.debug_memory_shape()
-    );
-}
-
-fn process_rss_kib() -> Option<u64> {
-    let output = Command::new("ps")
-        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    String::from_utf8(output.stdout)
-        .ok()?
-        .trim()
-        .parse::<u64>()
-        .ok()
-}
-
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
@@ -378,15 +335,7 @@ impl LanguageServer for Backend {
         let uri = params.text_document.uri;
 
         let mut documents = self.documents.write().await;
-        if let Some(document) = documents.get(&uri) {
-            log_document_memory("before close remove", &uri, document);
-        }
         documents.remove(&uri);
-        eprintln!(
-            "[ifc-lsp memory] after close remove uri={} open_documents={}",
-            uri,
-            documents.len()
-        );
         drop(documents);
 
         self.client.publish_diagnostics(uri, Vec::new(), None).await;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -4,6 +4,7 @@
 //! Request handlers stay thin here and delegate document-specific work to the feature modules.
 
 use std::collections::HashMap;
+use std::process::Command;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -276,11 +277,31 @@ fn new_parser() -> tree_sitter::Parser {
 
 fn log_document_memory(event: &str, uri: &Url, document: &Document) {
     eprintln!(
-        "[ifc-lsp memory] {} uri={} {}",
+        "[ifc-lsp memory] {} uri={} rss_kib={} {}",
         event,
         uri,
+        process_rss_kib()
+            .map(|rss| rss.to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
         document.debug_memory_shape()
     );
+}
+
+fn process_rss_kib() -> Option<u64> {
+    let output = Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout)
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
 }
 
 #[tower_lsp::async_trait]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -10,7 +10,6 @@ use tokio::sync::RwLock;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
-use tree_sitter::Parser;
 
 use crate::config::{ServerConfig, expand_schema_candidates, parse_server_config};
 use crate::diagnostics::datatype;
@@ -30,22 +29,15 @@ struct SchemaConfigState {
 pub struct Backend {
     client: Client,
     documents: Arc<RwLock<HashMap<Url, Document>>>,
-    parser: Arc<RwLock<Parser>>,
     schema_docs: Arc<RwLock<SchemaDocCollection>>,
     schema_config: Arc<RwLock<SchemaConfigState>>,
 }
 
 impl Backend {
     pub fn new(client: Client) -> Self {
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_ifc::LANGUAGE.into())
-            .expect("Error loading IFC parser");
-
         Self {
             client,
             documents: Arc::new(RwLock::new(HashMap::new())),
-            parser: Arc::new(RwLock::new(parser)),
             schema_docs: Arc::new(RwLock::new(SchemaDocCollection::new())),
             schema_config: Arc::new(RwLock::new(SchemaConfigState::default())),
         }
@@ -118,7 +110,7 @@ impl Backend {
         document.text = text;
 
         {
-            let mut parser = self.parser.write().await;
+            let mut parser = new_parser();
             document.reload_parse_state(&mut parser);
         }
 
@@ -142,7 +134,7 @@ impl Backend {
         }
 
         {
-            let mut parser = self.parser.write().await;
+            let mut parser = new_parser();
             documents.get_mut(uri)?.reload_parse_state(&mut parser);
         }
 
@@ -259,6 +251,14 @@ impl Backend {
         *self.schema_docs.write().await = schema_docs;
         *self.schema_config.write().await = next_state;
     }
+}
+
+fn new_parser() -> tree_sitter::Parser {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_ifc::LANGUAGE.into())
+        .expect("Error loading IFC parser");
+    parser
 }
 
 #[tower_lsp::async_trait]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -99,20 +99,25 @@ impl Backend {
         let mut documents = self.documents.write().await;
         for (document_uri, document) in documents.iter_mut() {
             if document_uri != uri {
+                log_document_memory("before unload", document_uri, document);
                 document.unload_parse_state();
+                log_document_memory("after unload", document_uri, document);
             }
         }
 
         let document = documents
             .entry(uri.clone())
             .or_insert_with(|| Document::new_unloaded(String::new()));
+        log_document_memory("before active text reload", uri, document);
         document.unload_parse_state();
         document.text = text;
+        log_document_memory("after active text replace", uri, document);
 
         {
             let mut parser = new_parser();
             document.reload_parse_state(&mut parser);
         }
+        log_document_memory("after active reload", uri, document);
 
         self.check_schema_support(document).await;
         self.collect_diagnostics(document).await
@@ -129,13 +134,21 @@ impl Backend {
 
         for (document_uri, document) in documents.iter_mut() {
             if document_uri != uri {
+                log_document_memory("before unload", document_uri, document);
                 document.unload_parse_state();
+                log_document_memory("after unload", document_uri, document);
             }
         }
 
         {
             let mut parser = new_parser();
+            if let Some(document) = documents.get(uri) {
+                log_document_memory("before request reload", uri, document);
+            }
             documents.get_mut(uri)?.reload_parse_state(&mut parser);
+        }
+        if let Some(document) = documents.get(uri) {
+            log_document_memory("after request reload", uri, document);
         }
 
         let diagnostics = {
@@ -261,6 +274,15 @@ fn new_parser() -> tree_sitter::Parser {
     parser
 }
 
+fn log_document_memory(event: &str, uri: &Url, document: &Document) {
+    eprintln!(
+        "[ifc-lsp memory] {} uri={} {}",
+        event,
+        uri,
+        document.debug_memory_shape()
+    );
+}
+
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
@@ -335,7 +357,15 @@ impl LanguageServer for Backend {
         let uri = params.text_document.uri;
 
         let mut documents = self.documents.write().await;
+        if let Some(document) = documents.get(&uri) {
+            log_document_memory("before close remove", &uri, document);
+        }
         documents.remove(&uri);
+        eprintln!(
+            "[ifc-lsp memory] after close remove uri={} open_documents={}",
+            uri,
+            documents.len()
+        );
         drop(documents);
 
         self.client.publish_diagnostics(uri, Vec::new(), None).await;

--- a/src/document.rs
+++ b/src/document.rs
@@ -133,10 +133,10 @@ impl Document {
     pub fn unload_parse_state(&mut self) {
         self.tree = None;
         self.schema_name = None;
-        self.definitions.clear();
-        self.references.clear();
-        self.instances.clear();
-        self.instance_indexes_by_id.clear();
+        self.definitions = HashMap::new();
+        self.references = HashMap::new();
+        self.instances = Vec::new();
+        self.instance_indexes_by_id = HashMap::new();
     }
 
     pub fn reload_parse_state(&mut self, parser: &mut Parser) {

--- a/src/document.rs
+++ b/src/document.rs
@@ -159,23 +159,6 @@ impl Document {
         self.tree.is_some()
     }
 
-    pub fn debug_memory_shape(&self) -> String {
-        format!(
-            "text len={} cap={} tree={} definitions len={} cap={} references len={} cap={} instances len={} cap={} instance_indexes len={} cap={}",
-            self.text.len(),
-            self.text.capacity(),
-            self.tree.is_some(),
-            self.definitions.len(),
-            self.definitions.capacity(),
-            self.references.len(),
-            self.references.capacity(),
-            self.instances.len(),
-            self.instances.capacity(),
-            self.instance_indexes_by_id.len(),
-            self.instance_indexes_by_id.capacity(),
-        )
-    }
-
     pub fn node_at_position(&self, position: Position) -> Option<Node<'_>> {
         let tree = self.tree.as_ref()?;
         let point = Point {

--- a/src/document.rs
+++ b/src/document.rs
@@ -125,24 +125,9 @@ impl Document {
 
     #[cfg(test)]
     pub fn parse(parser: &mut Parser, text: String) -> Self {
-        let ParseState {
-            tree,
-            schema_name,
-            definitions,
-            references,
-            instances,
-            instance_indexes_by_id,
-        } = parse_state(parser, &text);
-
-        Self {
-            text,
-            tree,
-            schema_name,
-            definitions,
-            references,
-            instances,
-            instance_indexes_by_id,
-        }
+        let mut document = Self::new_unloaded(text);
+        document.reload_parse_state(parser);
+        document
     }
 
     pub fn unload_parse_state(&mut self) {
@@ -155,21 +140,19 @@ impl Document {
     }
 
     pub fn reload_parse_state(&mut self, parser: &mut Parser) {
-        let ParseState {
-            tree,
-            schema_name,
-            definitions,
-            references,
-            instances,
-            instance_indexes_by_id,
-        } = parse_state(parser, &self.text);
+        self.tree = parser.parse(&self.text, None);
+        self.schema_name = detect_schema(&self.tree, &self.text);
+        let (definitions, references, instances) = build_indexes(&self.tree, &self.text);
 
-        self.tree = tree;
-        self.schema_name = schema_name;
         self.definitions = definitions;
         self.references = references;
         self.instances = instances;
-        self.instance_indexes_by_id = instance_indexes_by_id;
+        self.instance_indexes_by_id = self
+            .instances
+            .iter()
+            .enumerate()
+            .filter_map(|(index, instance)| instance.id.map(|id| (id, index)))
+            .collect();
     }
 
     pub fn is_parse_state_loaded(&self) -> bool {
@@ -190,35 +173,6 @@ impl Document {
         self.instance_indexes_by_id
             .get(&id)
             .and_then(|index| self.instances.get(*index))
-    }
-}
-
-struct ParseState {
-    tree: Option<Tree>,
-    schema_name: Option<String>,
-    definitions: HashMap<u32, DefinitionInfo>,
-    references: HashMap<u32, Vec<Range>>,
-    instances: Vec<EntityInstanceInfo>,
-    instance_indexes_by_id: HashMap<u32, usize>,
-}
-
-fn parse_state(parser: &mut Parser, text: &str) -> ParseState {
-    let tree = parser.parse(text, None);
-    let schema_name = detect_schema(&tree, text);
-    let (definitions, references, instances) = build_indexes(&tree, text);
-    let instance_indexes_by_id = instances
-        .iter()
-        .enumerate()
-        .filter_map(|(index, instance)| instance.id.map(|id| (id, index)))
-        .collect();
-
-    ParseState {
-        tree,
-        schema_name,
-        definitions,
-        references,
-        instances,
-        instance_indexes_by_id,
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -111,15 +111,29 @@ impl ParameterValue {
 }
 
 impl Document {
+    pub fn new_unloaded(text: String) -> Self {
+        Self {
+            text,
+            tree: None,
+            schema_name: None,
+            definitions: HashMap::new(),
+            references: HashMap::new(),
+            instances: Vec::new(),
+            instance_indexes_by_id: HashMap::new(),
+        }
+    }
+
+    #[cfg(test)]
     pub fn parse(parser: &mut Parser, text: String) -> Self {
-        let tree = parser.parse(&text, None);
-        let schema_name = detect_schema(&tree, &text);
-        let (definitions, references, instances) = build_indexes(&tree, &text);
-        let instance_indexes_by_id = instances
-            .iter()
-            .enumerate()
-            .filter_map(|(index, instance)| instance.id.map(|id| (id, index)))
-            .collect();
+        let ParseState {
+            tree,
+            schema_name,
+            definitions,
+            references,
+            instances,
+            instance_indexes_by_id,
+        } = parse_state(parser, &text);
+
         Self {
             text,
             tree,
@@ -129,6 +143,37 @@ impl Document {
             instances,
             instance_indexes_by_id,
         }
+    }
+
+    pub fn unload_parse_state(&mut self) {
+        self.tree = None;
+        self.schema_name = None;
+        self.definitions.clear();
+        self.references.clear();
+        self.instances.clear();
+        self.instance_indexes_by_id.clear();
+    }
+
+    pub fn reload_parse_state(&mut self, parser: &mut Parser) {
+        let ParseState {
+            tree,
+            schema_name,
+            definitions,
+            references,
+            instances,
+            instance_indexes_by_id,
+        } = parse_state(parser, &self.text);
+
+        self.tree = tree;
+        self.schema_name = schema_name;
+        self.definitions = definitions;
+        self.references = references;
+        self.instances = instances;
+        self.instance_indexes_by_id = instance_indexes_by_id;
+    }
+
+    pub fn is_parse_state_loaded(&self) -> bool {
+        self.tree.is_some()
     }
 
     pub fn node_at_position(&self, position: Position) -> Option<Node<'_>> {
@@ -145,6 +190,35 @@ impl Document {
         self.instance_indexes_by_id
             .get(&id)
             .and_then(|index| self.instances.get(*index))
+    }
+}
+
+struct ParseState {
+    tree: Option<Tree>,
+    schema_name: Option<String>,
+    definitions: HashMap<u32, DefinitionInfo>,
+    references: HashMap<u32, Vec<Range>>,
+    instances: Vec<EntityInstanceInfo>,
+    instance_indexes_by_id: HashMap<u32, usize>,
+}
+
+fn parse_state(parser: &mut Parser, text: &str) -> ParseState {
+    let tree = parser.parse(text, None);
+    let schema_name = detect_schema(&tree, text);
+    let (definitions, references, instances) = build_indexes(&tree, text);
+    let instance_indexes_by_id = instances
+        .iter()
+        .enumerate()
+        .filter_map(|(index, instance)| instance.id.map(|id| (id, index)))
+        .collect();
+
+    ParseState {
+        tree,
+        schema_name,
+        definitions,
+        references,
+        instances,
+        instance_indexes_by_id,
     }
 }
 
@@ -586,5 +660,47 @@ mod tests {
         let instance = document.instance_by_id(2).expect("instance should exist");
 
         assert_eq!(instance.entity_name, "IFCDOOR");
+    }
+
+    #[test]
+    fn unload_parse_state_preserves_text_and_clears_derived_state() {
+        let text = "#1=IFCWALL(#2);";
+        let mut document = parse_document(text);
+
+        document.unload_parse_state();
+
+        assert_eq!(document.text, text);
+        assert!(!document.is_parse_state_loaded());
+        assert_eq!(document.schema_name, None);
+        assert!(document.definitions.is_empty());
+        assert!(document.references.is_empty());
+        assert!(document.instances.is_empty());
+        assert!(document.instance_indexes_by_id.is_empty());
+    }
+
+    #[test]
+    fn reload_parse_state_rebuilds_derived_state_from_existing_text() {
+        let text = "#1=IFCWALL(#2);\n#2=IFCDOOR($);";
+        let mut document = parse_document(text);
+        document.unload_parse_state();
+
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_ifc::LANGUAGE.into())
+            .expect("Error loading IFC parser");
+        document.reload_parse_state(&mut parser);
+
+        assert_eq!(document.text, text);
+        assert!(document.is_parse_state_loaded());
+        assert!(document.definitions.contains_key(&1));
+        assert!(document.definitions.contains_key(&2));
+        assert_eq!(document.references[&2].len(), 1);
+        assert_eq!(
+            document
+                .instance_by_id(2)
+                .expect("instance should be indexed")
+                .entity_name,
+            "IFCDOOR"
+        );
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -159,6 +159,23 @@ impl Document {
         self.tree.is_some()
     }
 
+    pub fn debug_memory_shape(&self) -> String {
+        format!(
+            "text len={} cap={} tree={} definitions len={} cap={} references len={} cap={} instances len={} cap={} instance_indexes len={} cap={}",
+            self.text.len(),
+            self.text.capacity(),
+            self.tree.is_some(),
+            self.definitions.len(),
+            self.definitions.capacity(),
+            self.references.len(),
+            self.references.capacity(),
+            self.instances.len(),
+            self.instances.capacity(),
+            self.instance_indexes_by_id.len(),
+            self.instance_indexes_by_id.capacity(),
+        )
+    }
+
     pub fn node_at_position(&self, position: Position) -> Option<Node<'_>> {
         let tree = self.tree.as_ref()?;
         let point = Point {


### PR DESCRIPTION
Keep raw text for all open documents, but unload tree-sitter parse state and indexes
from inactive documents.
- Reload parse state from retained editor text when a request targets an unloaded document.
- Remove the long-lived shared parser and create a parser per reload.
- Add didClose handling to remove closed documents and clear diagnostics.