### PR TITLE
Reduce reliance on AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Supported options:
   - These schemas are added to the server's schema selection pool.
   - When an IFC file declares a schema name that is not bundled, the server checks the configured local schemas for an exact `SCHEMA ...;` name match and loads the matching schema on demand.
 
+- `astFileSizeLimitMb`
+  - Maximum file size in MiB for AST-backed features.
+  - Defaults to `70`.
+  - Files above this limit keep basic hover/navigation available, but skip schema diagnostics and derived-value hover.
+
 Configuration changes currently require restarting the server.
 
 Example `initializationOptions`:
@@ -92,6 +97,7 @@ Example `initializationOptions`:
 ```json
 {
   "overwriteExpSchemaWithLocal": "/Users/alice/dev/express/IFC4x2.exp",
+  "astFileSizeLimitMb": 128,
   "addLocalSchemaToSelection": [
     "/Users/alice/dev/express/IFC4x1.exp",
     "/Users/alice/dev/express/custom-schemas"

--- a/build.rs
+++ b/build.rs
@@ -23,8 +23,7 @@ const SCHEMAS: &[(&str, &str, &str)] = &[
     ),
 ];
 
-const IFC2X3_ENTITY_INDEX_URL: &str =
-    "https://standards.buildingsmart.org/IFC/RELEASE/IFC2x3/TC1/HTML/alphabeticalorder_entities.htm";
+const IFC2X3_ENTITY_INDEX_URL: &str = "https://standards.buildingsmart.org/IFC/RELEASE/IFC2x3/TC1/HTML/alphabeticalorder_entities.htm";
 const IFC2X3_ENTITY_COUNT: usize = 653;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -75,6 +75,10 @@ impl Backend {
     }
 
     async fn collect_diagnostics(&self, document: &Document) -> Vec<Diagnostic> {
+        if !document.has_ast() {
+            return Vec::new();
+        }
+
         let selected_schema_name = self.selected_schema_name(&document).await;
         if let Some(schema_name) = selected_schema_name.as_deref() {
             let schema_docs = self.schema_docs.read().await;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3,7 +3,7 @@
 //! parser, and the in-memory schema docs used by hover and datatype diagnostics.
 //! Request handlers stay thin here and delegate document-specific work to the feature modules.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -13,7 +13,7 @@ use tower_lsp::{Client, LanguageServer};
 
 use crate::config::{ServerConfig, expand_schema_candidates, parse_server_config};
 use crate::diagnostics::datatype;
-use crate::document::Document;
+use crate::document::{DEFAULT_AST_FILE_SIZE_LIMIT_BYTES, Document};
 use crate::features::{definition, hover, references};
 use crate::schema::{
     SchemaDocCollection, inspect_local_schema_name, load_local_schema, normalize_name,
@@ -31,6 +31,7 @@ pub struct Backend {
     documents: Arc<RwLock<HashMap<Url, Document>>>,
     schema_docs: Arc<RwLock<SchemaDocCollection>>,
     schema_config: Arc<RwLock<SchemaConfigState>>,
+    ast_skip_warning_shown: Arc<RwLock<HashSet<Url>>>,
 }
 
 impl Backend {
@@ -40,7 +41,31 @@ impl Backend {
             documents: Arc::new(RwLock::new(HashMap::new())),
             schema_docs: Arc::new(RwLock::new(SchemaDocCollection::new())),
             schema_config: Arc::new(RwLock::new(SchemaConfigState::default())),
+            ast_skip_warning_shown: Arc::new(RwLock::new(HashSet::new())),
         }
+    }
+
+    async fn check_ast_support(&self, uri: &Url, text_len: usize) -> bool {
+        let mut shown = self.ast_skip_warning_shown.write().await;
+        if text_len <= DEFAULT_AST_FILE_SIZE_LIMIT_BYTES {
+            shown.remove(uri);
+            return false;
+        }
+
+        if shown.insert(uri.clone()) {
+            self.client
+                .show_message(
+                    MessageType::WARNING,
+                    format!(
+                        "This IFC file is larger than the AST parsing limit ({} MB).\nNavigation and basic hover remain available, but schema diagnostics and derived-value hover are disabled.",
+                        DEFAULT_AST_FILE_SIZE_LIMIT_BYTES / 1024 / 1024
+                    ),
+                )
+                .await;
+            return true;
+        }
+
+        false
     }
 
     async fn check_schema_support(&self, document: &Document) {
@@ -100,6 +125,10 @@ impl Backend {
     }
 
     async fn load_text_as_active_document(&self, uri: &Url, text: String) -> Vec<Diagnostic> {
+        if self.check_ast_support(uri, text.len()).await {
+            tokio::task::yield_now().await;
+        }
+
         let mut documents = self.documents.write().await;
         for (document_uri, document) in documents.iter_mut() {
             if document_uri != uri {
@@ -342,6 +371,7 @@ impl LanguageServer for Backend {
         documents.remove(&uri);
         drop(documents);
 
+        self.ast_skip_warning_shown.write().await.remove(&uri);
         self.client.publish_diagnostics(uri, Vec::new(), None).await;
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -19,18 +19,30 @@ use crate::schema::{
     SchemaDocCollection, inspect_local_schema_name, load_local_schema, normalize_name,
 };
 
-#[derive(Debug, Default)]
-struct SchemaConfigState {
+#[derive(Debug)]
+struct ConfigState {
     forced_schema_name: Option<String>,
     additional_schema_paths: HashMap<String, std::path::PathBuf>,
     pending_init_config: Option<ServerConfig>,
+    ast_file_size_limit_bytes: usize,
+}
+
+impl Default for ConfigState {
+    fn default() -> Self {
+        Self {
+            forced_schema_name: None,
+            additional_schema_paths: HashMap::new(),
+            pending_init_config: None,
+            ast_file_size_limit_bytes: DEFAULT_AST_FILE_SIZE_LIMIT_BYTES,
+        }
+    }
 }
 
 pub struct Backend {
     client: Client,
     documents: Arc<RwLock<HashMap<Url, Document>>>,
     schema_docs: Arc<RwLock<SchemaDocCollection>>,
-    schema_config: Arc<RwLock<SchemaConfigState>>,
+    config: Arc<RwLock<ConfigState>>,
     ast_skip_warning_shown: Arc<RwLock<HashSet<Url>>>,
 }
 
@@ -40,14 +52,18 @@ impl Backend {
             client,
             documents: Arc::new(RwLock::new(HashMap::new())),
             schema_docs: Arc::new(RwLock::new(SchemaDocCollection::new())),
-            schema_config: Arc::new(RwLock::new(SchemaConfigState::default())),
+            config: Arc::new(RwLock::new(ConfigState::default())),
             ast_skip_warning_shown: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
-    async fn check_ast_support(&self, uri: &Url, text_len: usize) -> bool {
+    async fn ast_file_size_limit_bytes(&self) -> usize {
+        self.config.read().await.ast_file_size_limit_bytes
+    }
+
+    async fn check_ast_support(&self, uri: &Url, text_len: usize, limit_bytes: usize) -> bool {
         let mut shown = self.ast_skip_warning_shown.write().await;
-        if text_len <= DEFAULT_AST_FILE_SIZE_LIMIT_BYTES {
+        if text_len <= limit_bytes {
             shown.remove(uri);
             return false;
         }
@@ -58,7 +74,7 @@ impl Backend {
                     MessageType::WARNING,
                     format!(
                         "This IFC file is larger than the AST parsing limit ({} MB).\nNavigation and basic hover remain available, but schema diagnostics and derived-value hover are disabled.",
-                        DEFAULT_AST_FILE_SIZE_LIMIT_BYTES / 1024 / 1024
+                        limit_bytes / 1024 / 1024
                     ),
                 )
                 .await;
@@ -69,7 +85,7 @@ impl Backend {
     }
 
     async fn check_schema_support(&self, document: &Document) {
-        let forced_schema_name = self.schema_config.read().await.forced_schema_name.clone();
+        let forced_schema_name = self.config.read().await.forced_schema_name.clone();
 
         if let Some(forced_schema_name) = forced_schema_name.as_deref()
             && let Some(document_schema_name) = document.schema_name.as_deref()
@@ -125,7 +141,11 @@ impl Backend {
     }
 
     async fn load_text_as_active_document(&self, uri: &Url, text: String) -> Vec<Diagnostic> {
-        if self.check_ast_support(uri, text.len()).await {
+        let ast_file_size_limit_bytes = self.ast_file_size_limit_bytes().await;
+        if self
+            .check_ast_support(uri, text.len(), ast_file_size_limit_bytes)
+            .await
+        {
             tokio::task::yield_now().await;
         }
 
@@ -144,7 +164,7 @@ impl Backend {
 
         {
             let mut parser = new_parser();
-            document.reload_parse_state(&mut parser);
+            document.reload_parse_state(&mut parser, ast_file_size_limit_bytes);
         }
 
         self.check_schema_support(document).await;
@@ -168,7 +188,9 @@ impl Backend {
 
         {
             let mut parser = new_parser();
-            documents.get_mut(uri)?.reload_parse_state(&mut parser);
+            documents
+                .get_mut(uri)?
+                .reload_parse_state(&mut parser, self.ast_file_size_limit_bytes().await);
         }
 
         let diagnostics = {
@@ -187,10 +209,10 @@ impl Backend {
 
     async fn selected_schema_name(&self, document: &Document) -> Option<String> {
         let (forced_schema_name, additional_path) = {
-            let schema_config = self.schema_config.read().await;
-            let forced_schema_name = schema_config.forced_schema_name.clone();
+            let config = self.config.read().await;
+            let forced_schema_name = config.forced_schema_name.clone();
             let additional_path = document.schema_name.as_ref().and_then(|schema_name| {
-                schema_config
+                config
                     .additional_schema_paths
                     .get(&normalize_name(schema_name))
                     .cloned()
@@ -233,7 +255,10 @@ impl Backend {
 
     async fn apply_config(&self, config: ServerConfig) {
         let mut schema_docs = SchemaDocCollection::new();
-        let mut next_state = SchemaConfigState::default();
+        let mut next_state = ConfigState {
+            ast_file_size_limit_bytes: config.ast_file_size_limit_bytes,
+            ..ConfigState::default()
+        };
 
         if let Some(path) = config.overwrite_exp_schema_with_local.as_ref() {
             match load_local_schema(path) {
@@ -282,7 +307,7 @@ impl Backend {
         }
 
         *self.schema_docs.write().await = schema_docs;
-        *self.schema_config.write().await = next_state;
+        *self.config.write().await = next_state;
     }
 }
 
@@ -303,8 +328,8 @@ impl LanguageServer for Backend {
             .map(parse_server_config)
             .unwrap_or_default();
 
-        let mut schema_config = self.schema_config.write().await;
-        schema_config.pending_init_config = Some(pending_init_config);
+        let mut config = self.config.write().await;
+        config.pending_init_config = Some(pending_init_config);
 
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
@@ -331,8 +356,8 @@ impl LanguageServer for Backend {
         }
 
         let pending_init_config = {
-            let mut schema_config = self.schema_config.write().await;
-            schema_config.pending_init_config.take()
+            let mut config = self.config.write().await;
+            config.pending_init_config.take()
         };
 
         if let Some(config) = pending_init_config {
@@ -378,7 +403,7 @@ impl LanguageServer for Backend {
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
         let uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
-        let forced_schema_name = self.schema_config.read().await.forced_schema_name.clone();
+        let forced_schema_name = self.config.read().await.forced_schema_name.clone();
 
         let mut documents = self.documents.write().await;
         let diagnostics = match self.ensure_document_loaded(&mut documents, &uri).await {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,10 +7,23 @@ use std::path::{Path, PathBuf};
 
 use tower_lsp::lsp_types::LSPAny;
 
-#[derive(Clone, Debug, Default)]
+use crate::document::DEFAULT_AST_FILE_SIZE_LIMIT_BYTES;
+
+#[derive(Clone, Debug)]
 pub struct ServerConfig {
     pub overwrite_exp_schema_with_local: Option<PathBuf>,
     pub add_local_schema_to_selection: Vec<PathBuf>,
+    pub ast_file_size_limit_bytes: usize,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            overwrite_exp_schema_with_local: None,
+            add_local_schema_to_selection: Vec::new(),
+            ast_file_size_limit_bytes: DEFAULT_AST_FILE_SIZE_LIMIT_BYTES,
+        }
+    }
 }
 
 pub fn parse_server_config(value: &LSPAny) -> ServerConfig {
@@ -28,7 +41,21 @@ pub fn parse_server_config(value: &LSPAny) -> ServerConfig {
             .get("addLocalSchemaToSelection")
             .map(parse_path_list)
             .unwrap_or_default(),
+        ast_file_size_limit_bytes: object
+            .get("astFileSizeLimitMb")
+            .and_then(parse_size_limit_mb)
+            .unwrap_or(DEFAULT_AST_FILE_SIZE_LIMIT_BYTES),
     }
+}
+
+fn parse_size_limit_mb(value: &LSPAny) -> Option<usize> {
+    let mb = value.as_f64()?;
+    if !mb.is_finite() || mb <= 0.0 {
+        return None;
+    }
+
+    let bytes = mb * 1024.0 * 1024.0;
+    (bytes <= usize::MAX as f64).then_some(bytes as usize)
 }
 
 fn parse_path_list(value: &LSPAny) -> Vec<PathBuf> {

--- a/src/diagnostics/datatype.rs
+++ b/src/diagnostics/datatype.rs
@@ -291,19 +291,19 @@ fn validate_entity_reference(
         ));
     };
 
-    let Some(definition) = document.definitions.get(id) else {
+    let Some(instance) = document.instance_by_id(*id) else {
         return Some(format!(
             "reference `#{}` does not resolve to a local entity",
             id
         ));
     };
 
-    if schema.is_entity_compatible(&definition.entity_name, expected_entity) {
+    if schema.is_entity_compatible(&instance.entity_name, expected_entity) {
         None
     } else {
         Some(format!(
             "expected reference to `{}` but `#{}` points to `{}`",
-            expected_entity, id, definition.entity_name
+            expected_entity, id, instance.entity_name
         ))
     }
 }
@@ -487,50 +487,43 @@ mod tests {
     /// Test that the datatype validator reports unresolved references.
     #[test]
     fn datatype_validator_reports_unresolved_reference() {
-        // `tree` is not necessary for this test, as the validator resolves references without it.
-        let document = Document {
-            text: "#1=IFCWALL('gid',.MOVABLE.);".to_string(),
-            tree: None,
-            schema_name: None,
-            definitions: HashMap::new(),
-            references: HashMap::new(),
-            instances: vec![crate::document::EntityInstanceInfo {
-                id: Some(1),
-                id_range: Some(Range {
-                    start: Position::new(0, 0),
-                    end: Position::new(0, 2),
-                }),
-                entity_name: "IFCWALL".to_string(),
-                entity_name_range: Range {
-                    start: Position::new(0, 3),
-                    end: Position::new(0, 10),
-                },
-                entity_range: Range {
-                    start: Position::new(0, 0),
-                    end: Position::new(0, 27),
-                },
-                parameter_list_range: Some(Range {
-                    start: Position::new(0, 10),
-                    end: Position::new(0, 27),
-                }),
-                parameters: vec![
-                    ParameterValue::String {
-                        range: Range {
-                            start: Position::new(0, 11),
-                            end: Position::new(0, 16),
-                        },
+        let mut document = Document::new_unloaded("#1=IFCWALL('gid',.MOVABLE.);".to_string());
+        document.instances = vec![crate::document::EntityInstanceInfo {
+            id: Some(1),
+            id_range: Some(Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 2),
+            }),
+            entity_name: "IFCWALL".to_string(),
+            entity_name_range: Range {
+                start: Position::new(0, 3),
+                end: Position::new(0, 10),
+            },
+            entity_range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 27),
+            },
+            parameter_list_range: Some(Range {
+                start: Position::new(0, 10),
+                end: Position::new(0, 27),
+            }),
+            parameters: vec![
+                ParameterValue::String {
+                    range: Range {
+                        start: Position::new(0, 11),
+                        end: Position::new(0, 16),
                     },
-                    ParameterValue::Reference {
-                        id: 2,
-                        range: Range {
-                            start: Position::new(0, 17),
-                            end: Position::new(0, 19),
-                        },
+                },
+                ParameterValue::Reference {
+                    id: 2,
+                    range: Range {
+                        start: Position::new(0, 17),
+                        end: Position::new(0, 19),
                     },
-                ],
-            }],
-            instance_indexes_by_id: HashMap::from([(1, 0)]),
-        };
+                },
+            ],
+        }];
+        document.instance_indexes_by_id = HashMap::from([(1, 0)]);
 
         let schema = schema_from(
             r#"

--- a/src/document.rs
+++ b/src/document.rs
@@ -151,11 +151,11 @@ impl Document {
         self.instance_indexes_by_id = HashMap::new();
     }
 
-    pub fn reload_parse_state(&mut self, parser: &mut Parser) {
+    pub fn reload_parse_state(&mut self, parser: &mut Parser, ast_file_size_limit_bytes: usize) {
         self.reload_text_index();
         self.unload_parse_state();
 
-        if self.text.len() > DEFAULT_AST_FILE_SIZE_LIMIT_BYTES {
+        if self.text.len() > ast_file_size_limit_bytes {
             self.ast_skipped = true;
             return;
         }
@@ -173,7 +173,7 @@ impl Document {
     #[cfg(test)]
     pub fn parse(parser: &mut Parser, text: String) -> Self {
         let mut document = Self::new_unloaded(text);
-        document.reload_parse_state(parser);
+        document.reload_parse_state(parser, DEFAULT_AST_FILE_SIZE_LIMIT_BYTES);
         document
     }
 
@@ -738,7 +738,7 @@ mod tests {
         parser
             .set_language(&tree_sitter_ifc::LANGUAGE.into())
             .expect("Error loading IFC parser");
-        document.reload_parse_state(&mut parser);
+        document.reload_parse_state(&mut parser, DEFAULT_AST_FILE_SIZE_LIMIT_BYTES);
 
         assert_eq!(document.text, text);
         assert!(document.is_parse_state_loaded());

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,29 +1,27 @@
 //! Parsed in-memory representation of one IFC document.
-//! This module turns full IFC source text into a tree-sitter parse plus the small indexes the
-//! language server needs for hover, definition, references, and schema-aware diagnostics.
-//! It also stores structured parameter values so diagnostics can validate attribute arguments.
+//! This module owns the source text, cheap text indexes for navigation, and optional tree-sitter
+//! state for schema-aware diagnostics and derived-value hover.
 
 use std::collections::HashMap;
 
 use tower_lsp::lsp_types::{Position, Range};
 use tree_sitter::{Node, Parser, Point, Tree, TreeCursor};
 
+use crate::document_index::{TextIndex, scan_text};
+
+pub const DEFAULT_AST_FILE_SIZE_LIMIT_BYTES: usize = 70 * 1024 * 1024;
+
 #[derive(Debug)]
 pub struct Document {
     pub text: String,
     pub tree: Option<Tree>,
+    pub ast_skipped: bool,
     pub schema_name: Option<String>,
-    pub definitions: HashMap<u32, DefinitionInfo>,
-    pub references: HashMap<u32, Vec<Range>>,
+    pub line_offsets: Vec<usize>,
+    pub definitions: HashMap<u32, usize>,
+    pub references: HashMap<u32, Vec<usize>>,
     pub instances: Vec<EntityInstanceInfo>,
     pub(crate) instance_indexes_by_id: HashMap<u32, usize>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DefinitionInfo {
-    pub id_range: Range,
-    pub entity_range: Range,
-    pub entity_name: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -36,12 +34,6 @@ pub struct EntityInstanceInfo {
     pub parameter_list_range: Option<Range>,
     pub parameters: Vec<ParameterValue>,
 }
-
-type DocumentIndexes = (
-    HashMap<u32, DefinitionInfo>,
-    HashMap<u32, Vec<Range>>,
-    Vec<EntityInstanceInfo>,
-);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ParameterValue {
@@ -112,15 +104,70 @@ impl ParameterValue {
 
 impl Document {
     pub fn new_unloaded(text: String) -> Self {
+        let TextIndex {
+            line_offsets,
+            definitions,
+            references,
+            schema_name,
+        } = scan_text(&text);
+
         Self {
             text,
             tree: None,
+            ast_skipped: false,
             schema_name: None,
-            definitions: HashMap::new(),
-            references: HashMap::new(),
+            line_offsets,
+            definitions,
+            references,
             instances: Vec::new(),
             instance_indexes_by_id: HashMap::new(),
         }
+        .with_schema_name(schema_name)
+    }
+
+    fn with_schema_name(mut self, schema_name: Option<String>) -> Self {
+        self.schema_name = schema_name;
+        self
+    }
+
+    pub fn reload_text_index(&mut self) {
+        let TextIndex {
+            line_offsets,
+            definitions,
+            references,
+            schema_name,
+        } = scan_text(&self.text);
+
+        self.line_offsets = line_offsets;
+        self.definitions = definitions;
+        self.references = references;
+        self.schema_name = schema_name;
+    }
+
+    pub fn unload_parse_state(&mut self) {
+        self.tree = None;
+        self.ast_skipped = false;
+        self.instances = Vec::new();
+        self.instance_indexes_by_id = HashMap::new();
+    }
+
+    pub fn reload_parse_state(&mut self, parser: &mut Parser) {
+        self.reload_text_index();
+        self.unload_parse_state();
+
+        if self.text.len() > DEFAULT_AST_FILE_SIZE_LIMIT_BYTES {
+            self.ast_skipped = true;
+            return;
+        }
+
+        self.tree = parser.parse(&self.text, None);
+        self.instances = build_instances(&self.tree, &self.text);
+        self.instance_indexes_by_id = self
+            .instances
+            .iter()
+            .enumerate()
+            .filter_map(|(index, instance)| instance.id.map(|id| (id, index)))
+            .collect();
     }
 
     #[cfg(test)]
@@ -130,32 +177,11 @@ impl Document {
         document
     }
 
-    pub fn unload_parse_state(&mut self) {
-        self.tree = None;
-        self.schema_name = None;
-        self.definitions = HashMap::new();
-        self.references = HashMap::new();
-        self.instances = Vec::new();
-        self.instance_indexes_by_id = HashMap::new();
-    }
-
-    pub fn reload_parse_state(&mut self, parser: &mut Parser) {
-        self.tree = parser.parse(&self.text, None);
-        self.schema_name = detect_schema(&self.tree, &self.text);
-        let (definitions, references, instances) = build_indexes(&self.tree, &self.text);
-
-        self.definitions = definitions;
-        self.references = references;
-        self.instances = instances;
-        self.instance_indexes_by_id = self
-            .instances
-            .iter()
-            .enumerate()
-            .filter_map(|(index, instance)| instance.id.map(|id| (id, index)))
-            .collect();
-    }
-
     pub fn is_parse_state_loaded(&self) -> bool {
+        self.tree.is_some() || self.ast_skipped
+    }
+
+    pub fn has_ast(&self) -> bool {
         self.tree.is_some()
     }
 
@@ -174,139 +200,244 @@ impl Document {
             .get(&id)
             .and_then(|index| self.instances.get(*index))
     }
-}
 
-fn detect_schema(tree: &Option<Tree>, text: &str) -> Option<String> {
-    extract_file_schema_name(tree, text)
-}
+    pub fn position_to_offset(&self, position: Position) -> Option<usize> {
+        let line_start = *self.line_offsets.get(position.line as usize)?;
+        let line_end = self.line_end_offset(position.line as usize)?;
+        let line = self.text.get(line_start..line_end)?;
+        let mut utf16_units = 0u32;
 
-fn extract_file_schema_name(tree: &Option<Tree>, text: &str) -> Option<String> {
-    let tree = tree.as_ref()?;
-    let mut cursor = tree.root_node().walk();
-
-    find_file_schema_name(&mut cursor, text)
-}
-
-fn find_file_schema_name(cursor: &mut TreeCursor, text: &str) -> Option<String> {
-    loop {
-        let node = cursor.node();
-
-        if node.kind() == "header_entry"
-            && let Some(schema_name) = parse_file_schema_entry(node, text)
-        {
-            return Some(schema_name);
+        if position.character == 0 {
+            return Some(line_start);
         }
 
-        if cursor.goto_first_child() {
-            if let Some(schema_name) = find_file_schema_name(cursor, text) {
-                cursor.goto_parent();
-                return Some(schema_name);
+        for (byte_offset, character) in line.char_indices() {
+            if utf16_units == position.character {
+                return Some(line_start + byte_offset);
             }
-            cursor.goto_parent();
+            utf16_units += character.len_utf16() as u32;
         }
 
-        if !cursor.goto_next_sibling() {
-            break;
+        (utf16_units == position.character).then_some(line_end)
+    }
+
+    pub fn offset_to_position(&self, offset: usize) -> Option<Position> {
+        if offset > self.text.len() || !self.text.is_char_boundary(offset) {
+            return None;
+        }
+
+        let line_index = match self.line_offsets.binary_search(&offset) {
+            Ok(line) => line,
+            Err(next_line) => next_line.checked_sub(1)?,
+        };
+        let line_start = self.line_offsets[line_index];
+        let line_text = self.text.get(line_start..offset)?;
+        let character = line_text
+            .chars()
+            .map(|character| character.len_utf16() as u32)
+            .sum();
+
+        Some(Position::new(line_index as u32, character))
+    }
+
+    pub fn range_for_offsets(&self, start: usize, end: usize) -> Option<Range> {
+        Some(Range {
+            start: self.offset_to_position(start)?,
+            end: self.offset_to_position(end)?,
+        })
+    }
+
+    pub fn id_range_at_offset(&self, offset: usize) -> Option<Range> {
+        let (start, end, _) = self.id_token_at_offset(offset)?;
+        self.range_for_offsets(start, end)
+    }
+
+    pub fn definition_range(&self, id: u32) -> Option<Range> {
+        self.id_range_at_offset(*self.definitions.get(&id)?)
+    }
+
+    pub fn id_token_at_position(&self, position: Position) -> Option<(u32, usize)> {
+        let offset = self.position_to_offset(position)?;
+        let (start, _, id) = self.id_token_at_offset(offset)?;
+        self.references.get(&id)?.contains(&start).then_some(())?;
+        Some((id, start))
+    }
+
+    pub fn entity_name_at_position(&self, position: Position) -> Option<(String, Range)> {
+        let offset = self.position_to_offset(position)?;
+        let (start, end) = self.identifier_at_offset(offset)?;
+        if !self.is_definition_entity_name(start) {
+            return None;
+        }
+        let text = self.text.get(start..end)?;
+        Some((
+            text.to_ascii_uppercase(),
+            self.range_for_offsets(start, end)?,
+        ))
+    }
+
+    pub fn entity_instance_text_at_definition(&self, id: u32) -> Option<&str> {
+        let definition_offset = *self.definitions.get(&id)?;
+        let bytes = self.text.as_bytes();
+        let mut start = definition_offset;
+        while start > 0 && bytes[start - 1] != b';' {
+            start -= 1;
+        }
+        while start < definition_offset && bytes[start].is_ascii_whitespace() {
+            start += 1;
+        }
+
+        let mut end = definition_offset;
+        while end < bytes.len() && bytes[end] != b';' {
+            end += 1;
+        }
+        if end < bytes.len() {
+            end += 1;
+        }
+
+        self.text.get(start..end)
+    }
+
+    fn line_end_offset(&self, line_index: usize) -> Option<usize> {
+        let line_start = *self.line_offsets.get(line_index)?;
+        let next_line_start = self
+            .line_offsets
+            .get(line_index + 1)
+            .copied()
+            .unwrap_or(self.text.len());
+        if next_line_start > line_start
+            && self
+                .text
+                .as_bytes()
+                .get(next_line_start - 1)
+                .is_some_and(|byte| *byte == b'\n')
+        {
+            Some(next_line_start - 1)
+        } else {
+            Some(next_line_start)
         }
     }
 
-    None
+    fn id_token_at_offset(&self, offset: usize) -> Option<(usize, usize, u32)> {
+        let bytes = self.text.as_bytes();
+        if bytes.is_empty() {
+            return None;
+        }
+
+        let candidate =
+            if offset < bytes.len() && (bytes[offset] == b'#' || bytes[offset].is_ascii_digit()) {
+                offset
+            } else if offset > 0 && bytes[offset - 1].is_ascii_digit() {
+                offset - 1
+            } else {
+                return None;
+            };
+
+        let mut start = candidate;
+        while start > 0 && bytes[start - 1].is_ascii_digit() {
+            start -= 1;
+        }
+        if bytes.get(start) != Some(&b'#') {
+            start = start.checked_sub(1)?;
+            if bytes.get(start) != Some(&b'#') {
+                return None;
+            }
+        }
+
+        let mut end = start + 1;
+        let mut id = 0u32;
+        let mut has_digit = false;
+        while let Some(byte) = bytes.get(end).copied()
+            && byte.is_ascii_digit()
+        {
+            has_digit = true;
+            id = id.checked_mul(10)?.checked_add((byte - b'0') as u32)?;
+            end += 1;
+        }
+
+        (has_digit && offset <= end).then_some((start, end, id))
+    }
+
+    fn identifier_at_offset(&self, offset: usize) -> Option<(usize, usize)> {
+        let bytes = self.text.as_bytes();
+        if bytes.is_empty() {
+            return None;
+        }
+
+        let candidate = if offset < bytes.len() && is_identifier_part(bytes[offset]) {
+            offset
+        } else if offset > 0 && is_identifier_part(bytes[offset - 1]) {
+            offset - 1
+        } else {
+            return None;
+        };
+
+        let mut start = candidate;
+        while start > 0 && is_identifier_part(bytes[start - 1]) {
+            start -= 1;
+        }
+        let mut end = candidate + 1;
+        while end < bytes.len() && is_identifier_part(bytes[end]) {
+            end += 1;
+        }
+
+        Some((start, end))
+    }
+
+    fn is_definition_entity_name(&self, identifier_start: usize) -> bool {
+        let bytes = self.text.as_bytes();
+        let mut offset = identifier_start;
+
+        while offset > 0 && bytes[offset - 1].is_ascii_whitespace() {
+            offset -= 1;
+        }
+        if offset == 0 || bytes[offset - 1] != b'=' {
+            return false;
+        }
+        offset -= 1;
+
+        while offset > 0 && bytes[offset - 1].is_ascii_whitespace() {
+            offset -= 1;
+        }
+        let digit_end = offset;
+        while offset > 0 && bytes[offset - 1].is_ascii_digit() {
+            offset -= 1;
+        }
+
+        digit_end > offset && offset > 0 && bytes[offset - 1] == b'#'
+    }
 }
 
-fn parse_file_schema_entry(node: Node<'_>, text: &str) -> Option<String> {
-    let mut cursor = node.walk();
-    let mut entry_name = None;
-    let mut parameter_list = None;
-
-    for child in node.children(&mut cursor) {
-        match child.kind() {
-            "entity_name" => entry_name = child.utf8_text(text.as_bytes()).ok(),
-            "parameter_list" => parameter_list = Some(child),
-            _ => {}
-        }
-    }
-
-    if entry_name? != "FILE_SCHEMA" {
-        return None;
-    }
-
-    let parameter_list = parameter_list?;
-    extract_first_string(parameter_list, text).map(|value| value.to_ascii_uppercase())
+fn is_identifier_part(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
-fn extract_first_string(node: Node<'_>, text: &str) -> Option<String> {
-    if node.kind() == "string" {
-        let raw = node.utf8_text(text.as_bytes()).ok()?;
-        return Some(raw.trim_matches('\'').to_string());
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if let Some(value) = extract_first_string(child, text) {
-            return Some(value);
-        }
-    }
-
-    None
-}
-
-fn build_indexes(tree: &Option<Tree>, text: &str) -> DocumentIndexes {
-    let mut definitions = HashMap::new();
-    let mut references = HashMap::new();
+fn build_instances(tree: &Option<Tree>, text: &str) -> Vec<EntityInstanceInfo> {
     let mut instances = Vec::new();
 
     let tree = match tree {
         Some(t) => t,
-        None => return (definitions, references, instances),
+        None => return instances,
     };
 
     let mut cursor = tree.root_node().walk();
-    traverse(
-        &mut cursor,
-        text,
-        &mut definitions,
-        &mut references,
-        &mut instances,
-    );
+    traverse(&mut cursor, text, &mut instances);
 
-    (definitions, references, instances)
+    instances
 }
 
-fn traverse(
-    cursor: &mut TreeCursor,
-    text: &str,
-    definitions: &mut HashMap<u32, DefinitionInfo>,
-    references: &mut HashMap<u32, Vec<Range>>,
-    instances: &mut Vec<EntityInstanceInfo>,
-) {
+fn traverse(cursor: &mut TreeCursor, text: &str, instances: &mut Vec<EntityInstanceInfo>) {
     loop {
         let node = cursor.node();
 
         if node.kind() == "entity_instance" {
             if let Some(instance) = parse_entity_instance(node, text) {
-                if let Some(id) = instance.id {
-                    definitions.insert(
-                        id,
-                        DefinitionInfo {
-                            id_range: instance
-                                .id_range
-                                .expect("definition ids should have a range"),
-                            entity_range: instance.entity_range,
-                            entity_name: instance.entity_name.clone(),
-                        },
-                    );
-                }
                 instances.push(instance);
             }
-        } else if node.kind() == "reference"
-            && let Ok(ref_text) = node.utf8_text(text.as_bytes())
-            && let Ok(id) = ref_text.trim_start_matches('#').parse::<u32>()
-        {
-            references.entry(id).or_default().push(node_range(&node));
         }
 
         if cursor.goto_first_child() {
-            traverse(cursor, text, definitions, references, instances);
+            traverse(cursor, text, instances);
             cursor.goto_parent();
         }
 
@@ -485,8 +616,6 @@ fn node_range(node: &Node<'_>) -> Range {
 mod tests {
     use super::*;
 
-    /// Helper Function
-    /// Parses the given text and returns a [`Document`] with the text and initial state set.
     fn parse_document(text: &str) -> Document {
         let mut parser = Parser::new();
         parser
@@ -496,34 +625,34 @@ mod tests {
         Document::parse(&mut parser, text.to_string())
     }
 
-    /// Helper Function
-    /// Returns the position of the first occurrence of `needle` in `text`.
     fn position_at(text: &str, needle: &str) -> Position {
-        let offset = text.find(needle).expect("needle should exist") as u32;
-        Position::new(0, offset)
+        let offset = text.find(needle).expect("needle should exist");
+        let document = Document::new_unloaded(text.to_string());
+        document
+            .offset_to_position(offset)
+            .expect("needle offset should convert to a position")
     }
 
-    /// Tests that [`Document::parse`] keeps the text and initial state set.
     #[test]
-    fn parse_keeps_text_and_initial_state() {
+    fn parse_builds_text_index_and_ast_state() {
         let text = "#1=IFCWALL($);";
         let document = parse_document(text);
+
         assert_eq!(document.text, text);
         assert!(document.tree.is_some());
         assert_eq!(document.schema_name, None);
-        // definitions and references are now populated, not empty
+        assert_eq!(document.definitions.get(&1), Some(&0));
+        assert_eq!(document.references.get(&1), Some(&vec![0]));
     }
 
-    /// Tests that [`Document::parse`] detects the schema name from the header.
     #[test]
-    fn parse_detects_custom_schema_name_from_header() {
+    fn parse_detects_schema_name_from_text_index() {
         let text = "ISO-10303-21;HEADER;FILE_SCHEMA(('IFC4X3_LOCAL_TEST'));ENDSEC;DATA;#1=IFCWALL($);ENDSEC;END-ISO-10303-21;";
         let document = parse_document(text);
 
         assert_eq!(document.schema_name.as_deref(), Some("IFC4X3_LOCAL_TEST"));
     }
 
-    /// Tests that [`Document::node_at_position`] finds the entity name.
     #[test]
     fn node_at_position_finds_entity_name() {
         let text = "#1=IFCWALL($);";
@@ -540,7 +669,6 @@ mod tests {
         );
     }
 
-    /// Tests that [`Document::node_at_position`] finds the reference.
     #[test]
     fn node_at_position_finds_reference() {
         let text = "#1=IFCWALL(#2);";
@@ -554,56 +682,24 @@ mod tests {
         assert_eq!(node.utf8_text(document.text.as_bytes()).ok(), Some("#2"));
     }
 
-    /// Tests that [`Document::parse`] indexes the entity definition.
     #[test]
-    fn parse_indexes_entity_definition() {
-        let text = "#1=IFCWALL($);";
+    fn text_index_records_definition_and_reference_occurrences() {
+        let text = "#1=IFCWALL(#2);\n#2=IFCDOOR(#1);";
         let document = parse_document(text);
-        assert!(document.definitions.contains_key(&1));
-        assert!(document.references.is_empty());
-        // "#1" starts at column 0, row 0 and ends at column 2, row 0
-        assert_eq!(
-            document.definitions[&1].id_range,
-            Range {
-                start: Position::new(0, 0),
-                end: Position::new(0, 2),
-            }
-        );
-        // "IFCWALL" starts at column 2, row 0 and ends at column 8, row 0
-        assert_eq!(
-            document.definitions[&1].entity_range,
-            Range {
-                start: Position::new(0, 0),
-                end: Position::new(0, text.len() as u32),
-            }
-        );
+
+        assert_eq!(document.definitions.get(&1), Some(&0));
+        assert_eq!(document.definitions.get(&2), Some(&16));
+        assert_eq!(document.references.get(&1), Some(&vec![0, 27]));
+        assert_eq!(document.references.get(&2), Some(&vec![11, 16]));
     }
 
-    /// Tests that [`Document::parse`] indexes multiple definitions.
     #[test]
-    fn parse_indexes_multiple_definitions() {
-        let text = "#1=IFCWALL($);\n#2=IFCDOOR($);";
-        let document = parse_document(text);
-        assert!(document.definitions.contains_key(&1));
-        assert!(document.definitions.contains_key(&2));
-        assert_eq!(document.definitions.len(), 2);
-    }
+    fn position_conversion_uses_utf16_columns() {
+        let document = Document::new_unloaded("a😀b\n#1=IFCWALL($);".to_string());
 
-    /// Tests that [`Document::parse`] indexes references.
-    #[test]
-    fn parse_indexes_references() {
-        let text = "#1=IFCWALL(#2);";
-        let document = parse_document(text);
-        assert!(document.references.contains_key(&2));
-        assert_eq!(document.references[&2].len(), 1);
-    }
-
-    /// Tests that [`Document::parse`] indexes multiple references to the same ID.
-    #[test]
-    fn parse_indexes_multiple_references_to_same_id() {
-        let text = "#1=IFCWALL(#2);\n#3=IFCDOOR(#2);";
-        let document = parse_document(text);
-        assert_eq!(document.references[&2].len(), 2);
+        assert_eq!(document.position_to_offset(Position::new(0, 3)), Some(5));
+        assert_eq!(document.offset_to_position(5), Some(Position::new(0, 3)));
+        assert_eq!(document.position_to_offset(Position::new(1, 0)), Some(7));
     }
 
     #[test]
@@ -617,7 +713,7 @@ mod tests {
     }
 
     #[test]
-    fn unload_parse_state_preserves_text_and_clears_derived_state() {
+    fn unload_parse_state_preserves_text_index_and_clears_ast_state() {
         let text = "#1=IFCWALL(#2);";
         let mut document = parse_document(text);
 
@@ -626,8 +722,8 @@ mod tests {
         assert_eq!(document.text, text);
         assert!(!document.is_parse_state_loaded());
         assert_eq!(document.schema_name, None);
-        assert!(document.definitions.is_empty());
-        assert!(document.references.is_empty());
+        assert_eq!(document.definitions.get(&1), Some(&0));
+        assert_eq!(document.references.get(&2), Some(&vec![11]));
         assert!(document.instances.is_empty());
         assert!(document.instance_indexes_by_id.is_empty());
     }
@@ -648,7 +744,7 @@ mod tests {
         assert!(document.is_parse_state_loaded());
         assert!(document.definitions.contains_key(&1));
         assert!(document.definitions.contains_key(&2));
-        assert_eq!(document.references[&2].len(), 1);
+        assert_eq!(document.references[&2], vec![11, 16]);
         assert_eq!(
             document
                 .instance_by_id(2)

--- a/src/document_index.rs
+++ b/src/document_index.rs
@@ -1,0 +1,260 @@
+//! Lightweight STEP text indexing.
+//! This scanner intentionally recognizes only the tokens needed for cheap LSP navigation:
+//! line starts, local instance ids, references, and FILE_SCHEMA declarations.
+
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub struct TextIndex {
+    pub line_offsets: Vec<usize>,
+    pub definitions: HashMap<u32, usize>,
+    pub references: HashMap<u32, Vec<usize>>,
+    pub schema_name: Option<String>,
+}
+
+pub fn scan_text(text: &str) -> TextIndex {
+    let bytes = text.as_bytes();
+    let mut index = TextIndex {
+        line_offsets: vec![0],
+        definitions: HashMap::new(),
+        references: HashMap::new(),
+        schema_name: None,
+    };
+    let mut offset = 0usize;
+
+    while offset < bytes.len() {
+        match bytes[offset] {
+            b'\n' => {
+                index.line_offsets.push(offset + 1);
+                offset += 1;
+            }
+            b'\'' => offset = skip_string(bytes, offset, &mut index.line_offsets),
+            b'/' if bytes.get(offset + 1) == Some(&b'*') => {
+                offset = skip_block_comment(bytes, offset, &mut index.line_offsets);
+            }
+            b'#' => {
+                if let Some((id, end)) = parse_id(bytes, offset) {
+                    index.references.entry(id).or_default().push(offset);
+                    if is_definition(bytes, end) {
+                        index.definitions.insert(id, offset);
+                    }
+                    offset = end;
+                } else {
+                    offset += 1;
+                }
+            }
+            byte if is_identifier_start(byte) => {
+                let ident_start = offset;
+                offset += 1;
+                while offset < bytes.len() && is_identifier_part(bytes[offset]) {
+                    offset += 1;
+                }
+                if index.schema_name.is_none()
+                    && eq_ignore_ascii_case(&bytes[ident_start..offset], b"FILE_SCHEMA")
+                {
+                    index.schema_name = parse_file_schema_name(bytes, offset);
+                }
+            }
+            _ => offset += 1,
+        }
+    }
+
+    index
+}
+
+fn parse_id(bytes: &[u8], offset: usize) -> Option<(u32, usize)> {
+    let mut end = offset + 1;
+    let mut id = 0u32;
+    let mut has_digit = false;
+
+    while let Some(byte) = bytes.get(end).copied()
+        && byte.is_ascii_digit()
+    {
+        has_digit = true;
+        id = id.checked_mul(10)?.checked_add((byte - b'0') as u32)?;
+        end += 1;
+    }
+
+    has_digit.then_some((id, end))
+}
+
+fn is_definition(bytes: &[u8], mut offset: usize) -> bool {
+    while let Some(byte) = bytes.get(offset).copied()
+        && byte.is_ascii_whitespace()
+    {
+        offset += 1;
+    }
+
+    bytes.get(offset) == Some(&b'=')
+}
+
+fn skip_string(bytes: &[u8], mut offset: usize, line_offsets: &mut Vec<usize>) -> usize {
+    offset += 1;
+    while offset < bytes.len() {
+        match bytes[offset] {
+            b'\n' => {
+                line_offsets.push(offset + 1);
+                offset += 1;
+            }
+            b'\'' => {
+                if bytes.get(offset + 1) == Some(&b'\'') {
+                    offset += 2;
+                } else {
+                    return offset + 1;
+                }
+            }
+            _ => offset += 1,
+        }
+    }
+    offset
+}
+
+fn skip_block_comment(bytes: &[u8], mut offset: usize, line_offsets: &mut Vec<usize>) -> usize {
+    offset += 2;
+    while offset + 1 < bytes.len() {
+        if bytes[offset] == b'*' && bytes[offset + 1] == b'/' {
+            return offset + 2;
+        }
+        if bytes[offset] == b'\n' {
+            line_offsets.push(offset + 1);
+        }
+        offset += 1;
+    }
+    bytes.len()
+}
+
+fn parse_file_schema_name(bytes: &[u8], mut offset: usize) -> Option<String> {
+    while offset < bytes.len() {
+        match bytes[offset] {
+            b'\'' => return parse_schema_string(bytes, offset),
+            b';' => return None,
+            b'/' if bytes.get(offset + 1) == Some(&b'*') => {
+                let mut ignored_line_offsets = Vec::new();
+                offset = skip_block_comment(bytes, offset, &mut ignored_line_offsets);
+            }
+            _ => offset += 1,
+        }
+    }
+
+    None
+}
+
+fn parse_schema_string(bytes: &[u8], mut offset: usize) -> Option<String> {
+    offset += 1;
+    let start = offset;
+    let mut value = Vec::new();
+
+    while offset < bytes.len() {
+        if bytes[offset] == b'\'' {
+            if bytes.get(offset + 1) == Some(&b'\'') {
+                value.extend_from_slice(&bytes[start..offset]);
+                value.push(b'\'');
+                offset += 2;
+                return parse_schema_string_tail(bytes, offset, value);
+            }
+            value.extend_from_slice(&bytes[start..offset]);
+            return String::from_utf8(value)
+                .ok()
+                .map(|schema_name| schema_name.to_ascii_uppercase());
+        }
+        offset += 1;
+    }
+
+    None
+}
+
+fn parse_schema_string_tail(bytes: &[u8], mut offset: usize, mut value: Vec<u8>) -> Option<String> {
+    let mut start = offset;
+    while offset < bytes.len() {
+        if bytes[offset] == b'\'' {
+            if bytes.get(offset + 1) == Some(&b'\'') {
+                value.extend_from_slice(&bytes[start..offset]);
+                value.push(b'\'');
+                offset += 2;
+                start = offset;
+            } else {
+                value.extend_from_slice(&bytes[start..offset]);
+                return String::from_utf8(value)
+                    .ok()
+                    .map(|schema_name| schema_name.to_ascii_uppercase());
+            }
+        } else {
+            offset += 1;
+        }
+    }
+
+    None
+}
+
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn is_identifier_part(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+fn eq_ignore_ascii_case(left: &[u8], right: &[u8]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(left, right)| left.eq_ignore_ascii_case(right))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scans_schema_definitions_references_and_lines() {
+        let text = "HEADER;FILE_SCHEMA(('IFC4'));\nDATA;\n#1=IFCWALL(#2);\n#2=IFCDOOR($);";
+
+        let index = scan_text(text);
+
+        assert_eq!(index.schema_name.as_deref(), Some("IFC4"));
+        assert_eq!(index.line_offsets, vec![0, 30, 36, 52]);
+        assert_eq!(index.definitions.get(&1), Some(&36));
+        assert_eq!(index.definitions.get(&2), Some(&52));
+        assert_eq!(index.references.get(&1), Some(&vec![36]));
+        assert_eq!(index.references.get(&2), Some(&vec![47, 52]));
+    }
+
+    #[test]
+    fn ignores_ids_inside_strings_and_comments() {
+        let text = "#1=IFCWALL('#2');/* #3=IFCDOOR($); */#4=IFCWINDOW(#1);";
+
+        let index = scan_text(text);
+
+        assert!(index.definitions.contains_key(&1));
+        assert!(index.definitions.contains_key(&4));
+        assert!(!index.definitions.contains_key(&3));
+        assert_eq!(index.references.get(&1), Some(&vec![0, 50]));
+        assert!(!index.references.contains_key(&2));
+        assert!(!index.references.contains_key(&3));
+    }
+
+    #[test]
+    #[ignore]
+    fn times_large_generated_index_scan() {
+        let mut text = String::from("HEADER;FILE_SCHEMA(('IFC4'));ENDSEC;DATA;\n");
+        let instance_count = 3_000_000u32;
+        for id in 1..=instance_count {
+            let previous = id.saturating_sub(1).max(1);
+            text.push_str(&format!("#{id}=IFCWALL(#{previous});\n"));
+        }
+
+        let started = std::time::Instant::now();
+        let index = scan_text(&text);
+        let elapsed = started.elapsed();
+
+        eprintln!(
+            "scanned {} bytes, {} definitions, {} reference ids in {:?}",
+            text.len(),
+            index.definitions.len(),
+            index.references.len(),
+            elapsed
+        );
+        assert_eq!(index.definitions.len(), instance_count as usize);
+    }
+}

--- a/src/features/definition.rs
+++ b/src/features/definition.rs
@@ -10,19 +10,13 @@ pub fn goto_definition(
     document: &Document,
     position: Position,
 ) -> Option<GotoDefinitionResponse> {
-    let node = document.node_at_position(position)?;
-
-    let id = if node.kind() == "reference" {
-        let text = node.utf8_text(document.text.as_bytes()).ok()?;
-        text.trim_start_matches('#').parse::<u32>().ok()?
-    } else {
+    let (id, offset) = document.id_token_at_position(position)?;
+    if document.definitions.get(&id) == Some(&offset) {
         return None;
-    };
-
-    let definition = document.definitions.get(&id)?;
+    }
 
     Some(GotoDefinitionResponse::Scalar(Location {
         uri: uri.clone(),
-        range: definition.id_range,
+        range: document.definition_range(id)?,
     }))
 }

--- a/src/features/hover.rs
+++ b/src/features/hover.rs
@@ -1,11 +1,11 @@
 //! Hover feature logic.
-//! Resolves the syntax node under the cursor and renders either schema-backed entity information
-//! or local reference previews from the current document.
+//! Resolves text tokens under the cursor and renders schema-backed entity information or local
+//! reference previews from the current document. Derived `*` hovers still use tree-sitter context.
 //! Hover stays synchronous by reading only the in-memory document and schema collections.
 
 use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position};
 
-use crate::document::{DefinitionInfo, Document};
+use crate::document::Document;
 use crate::schema::{EntityAttributeDoc, EntityDoc, SchemaDocCollection};
 use crate::step::{ast, derived, derived::ResolvedDerivedValue};
 
@@ -15,35 +15,33 @@ pub fn hover(
     schema_docs: &SchemaDocCollection,
     selected_schema_name: Option<&str>,
 ) -> Option<Hover> {
-    document.tree.as_ref()?;
+    if let Some((id, offset)) = document.id_token_at_position(position)
+        && document.definitions.get(&id) != Some(&offset)
+    {
+        return Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: render_reference_hover(document, id)?,
+            }),
+            range: Some(document.id_range_at_offset(offset)?),
+        });
+    }
+
+    if let Some((entity_text, range)) = document.entity_name_at_position(position)
+        && let Some(schema_name) = selected_schema_name.or(document.schema_name.as_deref())
+        && let Some(entity_doc) = schema_docs.get_entity_doc(schema_name, &entity_text)
+    {
+        return Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: render_entity_hover(entity_doc),
+            }),
+            range: Some(range),
+        });
+    }
 
     if let Some(node) = document.node_at_position(position) {
-        if node.kind() == "entity_name" {
-            let entity_text = node.utf8_text(document.text.as_bytes()).ok()?;
-            if let Some(schema_name) = selected_schema_name.or(document.schema_name.as_deref())
-                && let Some(entity_doc) = schema_docs.get_entity_doc(schema_name, entity_text)
-            {
-                return Some(Hover {
-                    contents: HoverContents::Markup(MarkupContent {
-                        kind: MarkupKind::Markdown,
-                        value: render_entity_hover(entity_doc),
-                    }),
-                    range: None,
-                });
-            }
-        } else if node.kind() == "reference" {
-            let reference_text = node.utf8_text(document.text.as_bytes()).ok()?;
-            let id = reference_text.trim_start_matches('#').parse::<u32>().ok()?;
-            let definition = document.definitions.get(&id)?;
-
-            return Some(Hover {
-                contents: HoverContents::Markup(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value: render_reference_hover(document, definition)?,
-                }),
-                range: Some(node_range(&node)),
-            });
-        } else if node.kind() == "omitted_value" {
+        if node.kind() == "omitted_value" {
             if let Some(schema_name) = selected_schema_name.or(document.schema_name.as_deref())
                 && let Some(schema) = schema_docs.get(schema_name)
             {
@@ -120,8 +118,8 @@ fn render_attribute_table(attributes: &[&EntityAttributeDoc], start_index: usize
     markdown
 }
 
-fn render_reference_hover(document: &Document, definition: &DefinitionInfo) -> Option<String> {
-    let preview = extract_range_text(document, definition.entity_range)?;
+fn render_reference_hover(document: &Document, id: u32) -> Option<String> {
+    let preview = document.entity_instance_text_at_definition(id)?;
 
     Some(format!("```ifc\n{}\n```", preview.trim()))
 }
@@ -144,30 +142,6 @@ fn omitted_value_hover(
         text.push_str(&note);
     }
     Some(text)
-}
-
-fn extract_range_text(document: &Document, range: tower_lsp::lsp_types::Range) -> Option<&str> {
-    let start = offset_at_position(&document.text, range.start)?;
-    let end = offset_at_position(&document.text, range.end)?;
-    document.text.get(start..end)
-}
-
-fn offset_at_position(text: &str, position: Position) -> Option<usize> {
-    let mut offset = 0usize;
-    let mut lines = text.split('\n');
-
-    for _ in 0..position.line {
-        let line = lines.next()?;
-        offset += line.len() + 1;
-    }
-
-    let line = lines.next()?;
-    let character = position.character as usize;
-    if character > line.len() {
-        return None;
-    }
-
-    Some(offset + character)
 }
 
 fn node_range(node: &tree_sitter::Node<'_>) -> tower_lsp::lsp_types::Range {
@@ -198,7 +172,7 @@ fn format_attribute_type(type_name: &str) -> String {
 //*----- TESTS BEGIN HERE -----*
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashSet;
 
     use super::*;
     use crate::schema::EntityAttributeDoc;
@@ -330,7 +304,7 @@ mod tests {
     #[test]
     fn hover_returns_schema_docs_for_entity_names_with_detected_version() {
         let text = "ISO-10303-21;HEADER;FILE_SCHEMA(('IFC4'));ENDSEC;DATA;#1=IFCWALL($);ENDSEC;END-ISO-10303-21;";
-        let document = parse_document(text);
+        let document = Document::new_unloaded(text.to_string());
 
         let hover = hover(
             &document,
@@ -365,7 +339,7 @@ mod tests {
     #[test]
     fn hover_returns_definition_preview_for_references() {
         let text = "#1=IFCWALL($);\n#2=IFCDOOR(#1);";
-        let document = parse_document(text);
+        let document = Document::new_unloaded(text.to_string());
 
         let hover = hover(
             &document,
@@ -496,19 +470,9 @@ mod tests {
         assert!(value.contains("derived value"));
     }
 
-    /// Test that hover returns none when there is no syntax tree.
-    /// This tests important defensive behavior, since `tree` is defined as `Option<Tree>`, which can be `None`.
     #[test]
-    fn hover_returns_none_without_a_syntax_tree() {
-        let document = Document {
-            text: "#1=IFCWALL($);".to_string(),
-            tree: None,
-            schema_name: None,
-            definitions: HashMap::new(),
-            references: HashMap::new(),
-            instances: Vec::new(),
-            instance_indexes_by_id: HashMap::new(),
-        };
+    fn hover_returns_none_for_definition_id_without_a_syntax_tree() {
+        let document = Document::new_unloaded("#1=IFCWALL($);".to_string());
 
         assert!(hover(&document, Position::new(0, 0), &empty_schema_docs(), None).is_none());
     }

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -12,30 +12,17 @@ pub fn find_references(
     document: &Document,
     position: Position,
 ) -> Option<Vec<Location>> {
-    let node = document.node_at_position(position)?;
-
-    let id_node = match node.kind() {
-        "instance_id" | "reference" => node,
-        _ => return None,
-    };
-
-    let text = id_node.utf8_text(document.text.as_bytes()).ok()?;
-    let id = text.trim_start_matches('#').parse::<u32>().ok()?;
+    let (id, _) = document.id_token_at_position(position)?;
 
     let mut locations = Vec::new();
 
-    if let Some(definition) = document.definitions.get(&id) {
-        locations.push(Location {
-            uri: uri.clone(),
-            range: definition.id_range,
-        });
-    }
-
-    if let Some(refs) = document.references.get(&id) {
-        locations.extend(refs.iter().map(|r| Location {
-            uri: uri.clone(),
-            range: *r,
-        }));
+    if let Some(offsets) = document.references.get(&id) {
+        for offset in offsets {
+            locations.push(Location {
+                uri: uri.clone(),
+                range: document.id_range_at_offset(*offset)?,
+            });
+        }
     }
 
     if locations.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod backend;
 mod config;
 mod diagnostics;
 mod document;
+mod document_index;
 mod features;
 mod schema;
 mod step;

--- a/src/step/derived.rs
+++ b/src/step/derived.rs
@@ -117,16 +117,13 @@ fn render_parameter_resolution(
     value: &ParameterValue,
 ) -> Option<(String, Option<String>)> {
     match value {
-        ParameterValue::Reference { id, .. } => {
-            let definition = document.definitions.get(id)?;
-            Some((
-                format!("`#{}`", id),
-                Some(format!(
-                    "```ifc\n{}\n```",
-                    extract_range_text(document, definition.entity_range)?.trim()
-                )),
-            ))
-        }
+        ParameterValue::Reference { id, .. } => Some((
+            format!("`#{}`", id),
+            Some(format!(
+                "```ifc\n{}\n```",
+                document.entity_instance_text_at_definition(*id)?.trim()
+            )),
+        )),
         ParameterValue::Enumeration { value, .. } => Some((format!("`.{}.`", value), None)),
         ParameterValue::Number { text, .. } => Some((format!("`{}`", text), None)),
         ParameterValue::Null { .. } => Some(("`$`".to_string(), None)),
@@ -144,30 +141,6 @@ struct ResolvedParameterValue {
     value: String,
     preview: Option<String>,
     resolution_note: Option<String>,
-}
-
-fn extract_range_text(document: &Document, range: tower_lsp::lsp_types::Range) -> Option<&str> {
-    let start = offset_at_position(&document.text, range.start)?;
-    let end = offset_at_position(&document.text, range.end)?;
-    document.text.get(start..end)
-}
-
-fn offset_at_position(text: &str, position: tower_lsp::lsp_types::Position) -> Option<usize> {
-    let mut offset = 0usize;
-    let mut lines = text.split('\n');
-
-    for _ in 0..position.line {
-        let line = lines.next()?;
-        offset += line.len() + 1;
-    }
-
-    let line = lines.next()?;
-    let character = position.character as usize;
-    if character > line.len() {
-        return None;
-    }
-
-    Some(offset + character)
 }
 
 fn ifc_dimensions_for_si_unit(unit_name: &str) -> Option<[i32; 7]> {


### PR DESCRIPTION
This PR reduces large-file memory usage by making the core IFC navigation index text-based instead of AST-based and remove AST generation above a threshold (default 70MB).

- As an alternative to the full AST I implemented a lightweight text scanner for:
  - schema detection from `FILE_SCHEMA`
  - line offsets
  - entity definitions
  - reference occurrences

This scanner is implemented in src/document_index.rs. It extracts the above mentioned information in a single pass over the text buffer to stay as performant as possible.
- Replace the rich definition/reference indexes that stored LSP ranges and metadata with compact byte-offset indexes and recompute lsp location on demand from the byte-offset (should save a considarable amount of memory).
- Add UTF-16-aware position/offset conversion helpers on `Document`.
- Keep tree-sitter optional and skip AST parsing above the configured file-size limit (default is 70MB but can client can overwrite this in the init options).
- Disable schema diagnostics and derived `*` hover when AST parsing is skipped. We can think about what parts of the diagnostics would be possible without AST at a later point.
- Keep basic hover, reference hover, go-to-definition, and find-references available without tree-sitter.
- Add a visible client warning when AST-backed features are disabled for large files.

  Closes #21
  Closes #57
  Closes #64 (derived-value hover still relies on the AST, but thats ok)
  Closes #68