### PR TITLE
remove unnecessary clone

### DIFF
--- a/src/schema/resolver.rs
+++ b/src/schema/resolver.rs
@@ -57,7 +57,7 @@ fn resolve_all_attributes(
         attributes.extend(resolve_all_attributes(entities, supertype, visiting));
     }
 
-    let derived_attributes = entity.derived_attributes.clone();
+    let derived_attributes = &entity.derived_attributes;
 
     attributes.extend(entity.attributes.iter().map(|attr| EntityAttributeDoc {
         name: attr.name.clone(),


### PR DESCRIPTION
Cloeses #74 by removing the unnecessary `clone()` in `resolver.rs`