### PR TITLE
Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ flake.lock
 AGENTS.md
 .claude/
 logs/
+samples/Gebaeude_1-rvt2019.ifc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,10 +1314,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,8 @@ dependencies = [
  "sha2",
  "tokio",
  "tower-lsp",
+ "tracing",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-ifc",
  "ureq",
@@ -674,6 +676,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -963,6 +974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1285,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1371,6 +1426,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 tree-sitter = "0.26"
 tree-sitter-ifc = "0.1.0"
+tracing = "0.1.44"
+tracing-subscriber = "0.3.23"
 
 [build-dependencies]
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 tree-sitter = "0.26"
 tree-sitter-ifc = "0.1.0"
-tracing = "0.1.44"
-tracing-subscriber = "0.3.23"
+tracing = { version = "0.1.44", features = ["attributes"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
 
 [build-dependencies]
 sha2 = "0.10"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,6 +75,13 @@ The server advertises:
 
 Diagnostics are published with `textDocument/publishDiagnostics` on open, change, and request-time reloads.
 
+## Logging
+
+Runtime logs are written to `stderr` through `tracing`. The language server keeps `stdout`
+reserved for the LSP protocol stream, while editor integrations are expected to decide whether
+and how `stderr` should be captured into a log file. User-facing warnings still go through LSP
+notifications such as `window/showMessage`.
+
 ## Document Model
 
 `src/document.rs` is the central document representation:

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -54,6 +54,7 @@ Prefer the simplest implementation that matches the documented current scope in 
 - Prefer graceful fallbacks for unsupported schema versions, missing docs, absent syntax nodes, and documents without loaded AST state.
 - Use `expect` only when failure is truly unrecoverable or in tests.
 - Avoid panics in normal LSP request handling paths.
+- Prefer runtime logging through `tracing` on `stderr`; keep `stdout` reserved for the LSP protocol stream.
 
 ## Testing
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -10,6 +10,7 @@ use tokio::sync::RwLock;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
+use tracing::{debug, info, instrument, warn};
 
 use crate::config::{ServerConfig, expand_schema_candidates, parse_server_config};
 use crate::diagnostics::datatype;
@@ -61,6 +62,7 @@ impl Backend {
         self.config.read().await.ast_file_size_limit_bytes
     }
 
+    #[instrument(skip(self), fields(uri = %uri, text_len, limit_bytes))]
     async fn check_ast_support(&self, uri: &Url, text_len: usize, limit_bytes: usize) -> bool {
         let mut shown = self.ast_skip_warning_shown.write().await;
         if text_len <= limit_bytes {
@@ -78,12 +80,14 @@ impl Backend {
                     ),
                 )
                 .await;
+            warn!("skipping AST parse because document exceeds configured size limit");
             return true;
         }
 
         false
     }
 
+    #[instrument(skip(self, document), fields(schema_name = document.schema_name.as_deref().unwrap_or("<none>")))]
     async fn check_schema_support(&self, document: &Document) {
         let forced_schema_name = self.config.read().await.forced_schema_name.clone();
 
@@ -106,6 +110,7 @@ impl Backend {
         }
 
         if self.selected_schema_name(document).await.is_none() {
+            warn!("document schema is unknown or unsupported");
             self.client
                 .show_message(
                     MessageType::WARNING,
@@ -115,31 +120,41 @@ impl Backend {
         }
     }
 
+    #[instrument(skip(self, document), fields(has_ast = document.has_ast(), schema_name = document.schema_name.as_deref().unwrap_or("<none>")))]
     async fn collect_diagnostics(&self, document: &Document) -> Vec<Diagnostic> {
         if !document.has_ast() {
+            debug!("skipping diagnostics because AST is not loaded");
             return Vec::new();
         }
 
         let selected_schema_name = self.selected_schema_name(&document).await;
         if let Some(schema_name) = selected_schema_name.as_deref() {
             let schema_docs = self.schema_docs.read().await;
-            schema_docs
+            let diagnostics = schema_docs
                 .get(schema_name)
                 .map(|schema| {
                     datatype::collect_with_schema_name(&document, schema, Some(schema_name))
                 })
-                .unwrap_or_default()
+                .unwrap_or_default();
+            debug!(
+                diagnostic_count = diagnostics.len(),
+                "collected diagnostics"
+            );
+            diagnostics
         } else {
+            debug!("skipping diagnostics because no schema was selected");
             Vec::new()
         }
     }
 
+    #[instrument(skip(self, diagnostics), fields(uri = %uri, diagnostic_count = diagnostics.len()))]
     async fn publish_document_diagnostics(&self, uri: &Url, diagnostics: Vec<Diagnostic>) {
         self.client
             .publish_diagnostics(uri.clone(), diagnostics, None)
             .await;
     }
 
+    #[instrument(skip(self, text), fields(uri = %uri, text_len = text.len()))]
     async fn load_text_as_active_document(&self, uri: &Url, text: String) -> Vec<Diagnostic> {
         let ast_file_size_limit_bytes = self.ast_file_size_limit_bytes().await;
         if self
@@ -167,10 +182,20 @@ impl Backend {
             document.reload_parse_state(&mut parser, ast_file_size_limit_bytes);
         }
 
+        info!(
+            schema_name = document.schema_name.as_deref().unwrap_or("<none>"),
+            has_ast = document.has_ast(),
+            ast_skipped = document.ast_skipped,
+            definition_count = document.definitions.len(),
+            reference_id_count = document.references.len(),
+            instance_count = document.instances.len(),
+            "reloaded active document"
+        );
         self.check_schema_support(document).await;
         self.collect_diagnostics(document).await
     }
 
+    #[instrument(skip(self, documents), fields(uri = %uri))]
     async fn ensure_document_loaded(
         &self,
         documents: &mut HashMap<Url, Document>,
@@ -195,18 +220,29 @@ impl Backend {
 
         let diagnostics = {
             let document = documents.get(uri)?;
+            info!(
+                schema_name = document.schema_name.as_deref().unwrap_or("<none>"),
+                has_ast = document.has_ast(),
+                ast_skipped = document.ast_skipped,
+                definition_count = document.definitions.len(),
+                reference_id_count = document.references.len(),
+                instance_count = document.instances.len(),
+                "reloaded document parse state on demand"
+            );
             self.collect_diagnostics(document).await
         };
 
         Some(Some(diagnostics))
     }
 
+    #[instrument(skip(self, diagnostics), fields(uri = %uri))]
     async fn request_time_diagnostics(&self, diagnostics: Option<Vec<Diagnostic>>, uri: &Url) {
         if let Some(diagnostics) = diagnostics {
             self.publish_document_diagnostics(uri, diagnostics).await;
         }
     }
 
+    #[instrument(skip(self, document), fields(schema_name = document.schema_name.as_deref().unwrap_or("<none>")))]
     async fn selected_schema_name(&self, document: &Document) -> Option<String> {
         let (forced_schema_name, additional_path) = {
             let config = self.config.read().await;
@@ -241,18 +277,22 @@ impl Backend {
                 let mut schema_docs = self.schema_docs.write().await;
                 if schema_docs.get(&normalized_loaded).is_none() {
                     schema_docs.insert(&loaded_schema_name, schema);
+                    info!(
+                        schema_name = normalized_loaded,
+                        path = %path.display(),
+                        "loaded local schema documentation"
+                    );
                 }
                 Some(normalized_loaded)
             }
             Err(error) => {
-                self.client
-                    .log_message(MessageType::WARNING, error.to_string())
-                    .await;
+                warn!(error = %error, path = %path.display(), "failed to load local schema");
                 None
             }
         }
     }
 
+    #[instrument(skip(self, config), fields(ast_file_size_limit_bytes = config.ast_file_size_limit_bytes))]
     async fn apply_config(&self, config: ServerConfig) {
         let mut schema_docs = SchemaDocCollection::new();
         let mut next_state = ConfigState {
@@ -265,11 +305,14 @@ impl Backend {
                 Ok((schema_name, schema)) => {
                     next_state.forced_schema_name = Some(normalize_name(&schema_name));
                     schema_docs.insert(&schema_name, schema);
+                    info!(
+                        schema_name = next_state.forced_schema_name.as_deref().unwrap_or("<none>"),
+                        path = %path.display(),
+                        "configured forced local schema"
+                    );
                 }
                 Err(error) => {
-                    self.client
-                        .log_message(MessageType::WARNING, error.to_string())
-                        .await;
+                    warn!(error = %error, path = %path.display(), "failed to load forced local schema");
                 }
             }
         }
@@ -283,29 +326,26 @@ impl Backend {
                             .additional_schema_paths
                             .insert(normalized.clone(), candidate.clone())
                         {
-                            self.client
-                                .log_message(
-                                    MessageType::WARNING,
-                                    format!(
-                                        "Duplicate local schema `{}` configured at `{}` and `{}`; using `{}`",
-                                        normalized,
-                                        previous.display(),
-                                        candidate.display(),
-                                        candidate.display()
-                                    ),
-                                )
-                                .await;
+                            warn!(
+                                schema_name = normalized,
+                                previous_path = %previous.display(),
+                                candidate_path = %candidate.display(),
+                                "duplicate local schema configuration; using latest path"
+                            );
                         }
                     }
                     Err(error) => {
-                        self.client
-                            .log_message(MessageType::WARNING, error.to_string())
-                            .await;
+                        warn!(error = %error, path = %candidate.display(), "failed to inspect local schema");
                     }
                 }
             }
         }
 
+        info!(
+            forced_schema = next_state.forced_schema_name.as_deref().unwrap_or("<none>"),
+            additional_schema_count = next_state.additional_schema_paths.len(),
+            "applied server configuration"
+        );
         *self.schema_docs.write().await = schema_docs;
         *self.config.write().await = next_state;
     }
@@ -321,6 +361,7 @@ fn new_parser() -> tree_sitter::Parser {
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
+    #[instrument(skip(self, params))]
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         let pending_init_config = params
             .initialization_options
@@ -330,6 +371,7 @@ impl LanguageServer for Backend {
 
         let mut config = self.config.write().await;
         config.pending_init_config = Some(pending_init_config);
+        info!("received initialize request");
 
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
@@ -346,13 +388,11 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        self.client
-            .log_message(MessageType::INFO, "IFC LSP server initialized!")
-            .await;
+        info!("IFC LSP server initialized");
 
         let load_errors = self.schema_docs.read().await.load_errors().to_vec();
         for error in load_errors {
-            self.client.log_message(MessageType::WARNING, error).await;
+            warn!(error, "failed to load bundled schema documentation");
         }
 
         let pending_init_config = {
@@ -366,29 +406,32 @@ impl LanguageServer for Backend {
     }
 
     async fn shutdown(&self) -> Result<()> {
+        info!("received shutdown request");
         Ok(())
     }
 
+    #[instrument(skip(self, params), fields(uri = %params.text_document.uri))]
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let uri = params.text_document.uri;
         let text = params.text_document.text;
 
-        self.client
-            .log_message(MessageType::INFO, format!("Document opened: {}", uri))
-            .await;
+        info!(text_len = text.len(), "document opened");
 
         let diagnostics = self.load_text_as_active_document(&uri, text).await;
         self.publish_document_diagnostics(&uri, diagnostics).await;
     }
 
+    #[instrument(skip(self, params), fields(uri = %params.text_document.uri))]
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
         if let Some(change) = params.content_changes.into_iter().next() {
+            debug!(text_len = change.text.len(), "document changed");
             let diagnostics = self.load_text_as_active_document(&uri, change.text).await;
             self.publish_document_diagnostics(&uri, diagnostics).await;
         }
     }
 
+    #[instrument(skip(self, params), fields(uri = %params.text_document.uri))]
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = params.text_document.uri;
 
@@ -398,8 +441,10 @@ impl LanguageServer for Backend {
 
         self.ast_skip_warning_shown.write().await.remove(&uri);
         self.client.publish_diagnostics(uri, Vec::new(), None).await;
+        info!("document closed");
     }
 
+    #[instrument(skip(self, params), fields(uri = %params.text_document_position_params.text_document.uri))]
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
         let uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
@@ -415,13 +460,13 @@ impl LanguageServer for Backend {
             None => return Ok(None),
         };
 
-        let node_message = document.node_at_position(position).map(|node| {
-            format!(
-                "Node at cursor: kind={}, text={}",
-                node.kind(),
-                node.utf8_text(document.text.as_bytes()).unwrap_or("?")
-            )
-        });
+        if let Some(node) = document.node_at_position(position) {
+            debug!(
+                node_kind = node.kind(),
+                node_text = node.utf8_text(document.text.as_bytes()).unwrap_or("?"),
+                "resolved syntax node at hover position"
+            );
+        }
         let schema_docs = self.schema_docs.read().await;
 
         let result = hover::hover(
@@ -433,14 +478,13 @@ impl LanguageServer for Backend {
         drop(schema_docs);
         drop(documents);
 
-        if let Some(message) = node_message {
-            self.client.log_message(MessageType::INFO, message).await;
-        }
         self.request_time_diagnostics(diagnostics, &uri).await;
+        debug!(has_result = result.is_some(), "hover request completed");
 
         Ok(result)
     }
 
+    #[instrument(skip(self, params), fields(uri = %params.text_document_position_params.text_document.uri))]
     async fn goto_definition(
         &self,
         params: GotoDefinitionParams,
@@ -462,10 +506,16 @@ impl LanguageServer for Backend {
         drop(documents);
 
         self.request_time_diagnostics(diagnostics, &uri).await;
+        if result.is_some() {
+            debug!("go to definition resolved target");
+        } else {
+            debug!("go to definition found no target");
+        }
 
         Ok(result)
     }
 
+    #[instrument(skip(self, params), fields(uri = %params.text_document_position.text_document.uri))]
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
         let uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
@@ -484,6 +534,10 @@ impl LanguageServer for Backend {
         drop(documents);
 
         self.request_time_diagnostics(diagnostics, &uri).await;
+        debug!(
+            result_count = result.as_ref().map_or(0, Vec::len),
+            "find references request completed"
+        );
 
         Ok(result)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,13 +13,32 @@ mod step;
 
 use backend::Backend;
 use tower_lsp::{LspService, Server};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() {
+    init_logging();
+    info!("starting IFC language server");
+
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
     let (service, socket) = LspService::new(Backend::new);
 
     Server::new(stdin, stdout, socket).serve(service).await;
+
+    info!("IFC language server stopped");
+}
+
+fn init_logging() {
+    let env_filter = EnvFilter::try_from_env("IFC_LSP_LOG")
+        .or_else(|_| EnvFilter::try_from_default_env())
+        .unwrap_or_else(|_| EnvFilter::new("ifc_language_server=info,tower_lsp=warn"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
 }


### PR DESCRIPTION
Added a basic logging implementation using `tracing` and `tracing-subscriber`. The logs are sent to `stderr` and are intended to be handled by the extension implementation/editor. 

Timestamps are universally in UTC. Currently, basic debug information about feature requests, server start/stop, and file size warnings is logged. 