### PR TITLE
Semantic token

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Hover preview for entity references such as `#123`
 - Go-to-definition for local entity references
 - Find-references within the current document
+- Range-based semantic tokens for syntax highlighting
 - Schema-aware diagnostics for:
   - invalid local reference targets
   - primitive datatype mismatches
@@ -30,7 +31,7 @@ Bundled entity documentation is currently included for:
 - Full-document reparsing on open and change
 - Diagnostics currently focus on entity-instance argument validation, not full EXPRESS rule evaluation
 - No completion, rename, code actions, or formatting support
-- Syntax highlighting depends on editor grammar support such as `tree-sitter-ifc`; it is not provided by the LSP server itself
+- The LSP server provides range-based semantic tokens, but does not provide full-document semantic-token or TextMate grammar support
 
 ## Installation
 
@@ -88,7 +89,11 @@ Supported options:
 - `astFileSizeLimitMb`
   - Maximum file size in MiB for AST-backed features.
   - Defaults to `70`.
-  - Files above this limit keep basic hover/navigation available, but skip schema diagnostics and derived-value hover.
+  - Files above this limit keep basic hover/navigation and semantic tokens available, but skip schema diagnostics and derived-value hover.
+
+- `semanticTokensEnabled`
+  - Enables range-based semantic tokens.
+  - Defaults to `true`.
 
 Configuration changes currently require restarting the server.
 
@@ -98,6 +103,7 @@ Example `initializationOptions`:
 {
   "overwriteExpSchemaWithLocal": "/Users/alice/dev/express/IFC4x2.exp",
   "astFileSizeLimitMb": 128,
+  "semanticTokensEnabled": true,
   "addLocalSchemaToSelection": [
     "/Users/alice/dev/express/IFC4x1.exp",
     "/Users/alice/dev/express/custom-schemas"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,7 @@ The shipped LSP features are:
 - hover
 - go-to-definition
 - find-references
+- range-based semantic tokens
 - schema-aware diagnostics
 
 ## Core Design
@@ -53,6 +54,9 @@ On hover, definition, or references requests:
 3. The feature handler reads the stored `Document`.
 4. If request-time reloading produced diagnostics, they are published after the request.
 
+On semantic-token range requests, the backend reads the stored document text and text index only.
+Semantic-token requests do not reload tree-sitter parse state or publish diagnostics.
+
 There is still no incremental parsing, background indexing, or cross-document indexing.
 
 ## Backend
@@ -72,6 +76,7 @@ The server advertises:
 - full text document sync
 - `textDocument/definition`
 - `textDocument/references`
+- `textDocument/semanticTokens/range`
 
 Diagnostics are published with `textDocument/publishDiagnostics` on open, change, and request-time reloads.
 
@@ -160,7 +165,7 @@ When a file is larger than the limit:
 - tree-sitter parsing is skipped
 - schema diagnostics are disabled
 - derived `*` hover is disabled
-- basic hover and navigation remain available from the text index
+- basic hover, navigation, and range-based semantic tokens remain available from the text index/source text
 
 ## Feature AST Usage
 
@@ -171,6 +176,7 @@ These features do not require an AST:
 - go-to-definition for local `#id` references
 - find-references for local `#id` tokens
 - schema name detection from `FILE_SCHEMA(...)`
+- range-based semantic tokens
 
 These features require an AST:
 
@@ -206,6 +212,15 @@ At runtime, startup parses those bundled EXPRESS strings into a `SchemaDocCollec
 ### Find References
 
 `src/features/references.rs` returns all same-document text-indexed `#id` locations, including the definition token.
+
+### Semantic Tokens
+
+`src/features/semantic_tokens.rs` handles LSP semantic-token encoding for requested ranges.
+The lexer in `src/features/semantic_tokens/lexer.rs` scans borrowed document text and emits
+absolute byte ranges for STEP keywords, entity/type identifiers, instance ids, strings, numbers,
+enumerations, operators, and block comments.
+
+Semantic tokens do not use tree-sitter or schema docs.
 
 ### Diagnostics
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -54,6 +54,17 @@ The language server should implement find references functionality for IFC symbo
 
 For the current scope, this should be limited to a single document. Cross-file indexing is not required.
 
+### Semantic Tokens
+
+The language server should provide range-based semantic tokens for IFC STEP syntax highlighting.
+
+Semantic tokens should:
+
+- be enabled by default
+- be configurable through `initializationOptions.semanticTokensEnabled`
+- remain available without tree-sitter AST state
+- support large files through range requests rather than requiring full-document tokenization
+
 ### Large IFC Files
 
 The language server should remain usable for large IFC files without retaining tree-sitter ASTs for every open document.
@@ -64,6 +75,7 @@ For files above the configured AST parsing limit:
 - entity definition hover should remain available when schema docs are available
 - go-to-definition should remain available for local `#id` references
 - find-references should remain available for local `#id` tokens
+- range-based semantic tokens should remain available
 - AST-backed schema diagnostics may be disabled
 - derived `*` hover may be disabled
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, instrument, warn};
 use crate::config::{ServerConfig, expand_schema_candidates, parse_server_config};
 use crate::diagnostics::datatype;
 use crate::document::{DEFAULT_AST_FILE_SIZE_LIMIT_BYTES, Document};
-use crate::features::{definition, hover, references};
+use crate::features::{definition, hover, references, semantic_tokens};
 use crate::schema::{
     SchemaDocCollection, inspect_local_schema_name, load_local_schema, normalize_name,
 };
@@ -26,6 +26,7 @@ struct ConfigState {
     additional_schema_paths: HashMap<String, std::path::PathBuf>,
     pending_init_config: Option<ServerConfig>,
     ast_file_size_limit_bytes: usize,
+    semantic_tokens_enabled: bool,
 }
 
 impl Default for ConfigState {
@@ -35,6 +36,7 @@ impl Default for ConfigState {
             additional_schema_paths: HashMap::new(),
             pending_init_config: None,
             ast_file_size_limit_bytes: DEFAULT_AST_FILE_SIZE_LIMIT_BYTES,
+            semantic_tokens_enabled: true,
         }
     }
 }
@@ -297,6 +299,7 @@ impl Backend {
         let mut schema_docs = SchemaDocCollection::new();
         let mut next_state = ConfigState {
             ast_file_size_limit_bytes: config.ast_file_size_limit_bytes,
+            semantic_tokens_enabled: config.semantic_tokens_enabled,
             ..ConfigState::default()
         };
 
@@ -344,6 +347,7 @@ impl Backend {
         info!(
             forced_schema = next_state.forced_schema_name.as_deref().unwrap_or("<none>"),
             additional_schema_count = next_state.additional_schema_paths.len(),
+            semantic_tokens_enabled = next_state.semantic_tokens_enabled,
             "applied server configuration"
         );
         *self.schema_docs.write().await = schema_docs;
@@ -368,8 +372,18 @@ impl LanguageServer for Backend {
             .as_ref()
             .map(parse_server_config)
             .unwrap_or_default();
+        let semantic_tokens_enabled = pending_init_config.semantic_tokens_enabled;
+        let semantic_tokens_provider = semantic_tokens_enabled.then(|| {
+            SemanticTokensServerCapabilities::SemanticTokensOptions(SemanticTokensOptions {
+                work_done_progress_options: WorkDoneProgressOptions::default(),
+                legend: semantic_tokens::legend(),
+                range: Some(true),
+                full: None,
+            })
+        });
 
         let mut config = self.config.write().await;
+        config.semantic_tokens_enabled = semantic_tokens_enabled;
         config.pending_init_config = Some(pending_init_config);
         info!("received initialize request");
 
@@ -381,6 +395,7 @@ impl LanguageServer for Backend {
                 )),
                 definition_provider: Some(OneOf::Left(true)),
                 references_provider: Some(OneOf::Left(true)),
+                semantic_tokens_provider,
                 ..Default::default()
             },
             ..Default::default()
@@ -537,6 +552,34 @@ impl LanguageServer for Backend {
         debug!(
             result_count = result.as_ref().map_or(0, Vec::len),
             "find references request completed"
+        );
+
+        Ok(result)
+    }
+
+    #[instrument(skip(self, params), fields(uri = %params.text_document.uri))]
+    async fn semantic_tokens_range(
+        &self,
+        params: SemanticTokensRangeParams,
+    ) -> Result<Option<SemanticTokensRangeResult>> {
+        let uri = params.text_document.uri;
+        if !self.config.read().await.semantic_tokens_enabled {
+            return Ok(None);
+        }
+
+        let documents = self.documents.read().await;
+        let Some(document) = documents.get(&uri) else {
+            return Ok(None);
+        };
+
+        let result = semantic_tokens::semantic_tokens_range(document, params.range)
+            .map(SemanticTokensRangeResult::Tokens);
+        debug!(
+            result_count = result.as_ref().map_or(0, |result| match result {
+                SemanticTokensRangeResult::Tokens(tokens) => tokens.data.len(),
+                SemanticTokensRangeResult::Partial(partial) => partial.data.len(),
+            }),
+            "semantic tokens range request completed"
         );
 
         Ok(result)

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub struct ServerConfig {
     pub overwrite_exp_schema_with_local: Option<PathBuf>,
     pub add_local_schema_to_selection: Vec<PathBuf>,
     pub ast_file_size_limit_bytes: usize,
+    pub semantic_tokens_enabled: bool,
 }
 
 impl Default for ServerConfig {
@@ -22,6 +23,7 @@ impl Default for ServerConfig {
             overwrite_exp_schema_with_local: None,
             add_local_schema_to_selection: Vec::new(),
             ast_file_size_limit_bytes: DEFAULT_AST_FILE_SIZE_LIMIT_BYTES,
+            semantic_tokens_enabled: true,
         }
     }
 }
@@ -45,6 +47,10 @@ pub fn parse_server_config(value: &LSPAny) -> ServerConfig {
             .get("astFileSizeLimitMb")
             .and_then(parse_size_limit_mb)
             .unwrap_or(DEFAULT_AST_FILE_SIZE_LIMIT_BYTES),
+        semantic_tokens_enabled: object
+            .get("semanticTokensEnabled")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(true),
     }
 }
 
@@ -96,4 +102,27 @@ pub fn expand_schema_candidates(path: &Path) -> Vec<PathBuf> {
                     .is_some_and(|extension| extension.eq_ignore_ascii_case("exp"))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semantic_tokens_default_to_enabled() {
+        let value = "{}".parse::<LSPAny>().unwrap();
+
+        let config = parse_server_config(&value);
+
+        assert!(config.semantic_tokens_enabled);
+    }
+
+    #[test]
+    fn parses_semantic_tokens_enabled_flag() {
+        let value = r#"{"semanticTokensEnabled":false}"#.parse::<LSPAny>().unwrap();
+
+        let config = parse_server_config(&value);
+
+        assert!(!config.semantic_tokens_enabled);
+    }
 }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -5,3 +5,4 @@
 pub mod definition;
 pub mod hover;
 pub mod references;
+pub mod semantic_tokens;

--- a/src/features/semantic_tokens.rs
+++ b/src/features/semantic_tokens.rs
@@ -1,0 +1,237 @@
+//! Semantic-token feature handler.
+//! This module converts lexer output into LSP semantic-token deltas while keeping the lexer free
+//! of protocol types.
+
+#[path = "semantic_tokens/lexer.rs"]
+mod lexer;
+
+use tower_lsp::lsp_types::{
+    Position, Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
+    SemanticTokensLegend,
+};
+
+use crate::document::Document;
+use lexer::{LexedToken, TokenKind};
+
+pub fn legend() -> SemanticTokensLegend {
+    SemanticTokensLegend {
+        token_types: vec![
+            SemanticTokenType::KEYWORD,
+            SemanticTokenType::CLASS,
+            SemanticTokenType::VARIABLE,
+            SemanticTokenType::STRING,
+            SemanticTokenType::NUMBER,
+            SemanticTokenType::ENUM_MEMBER,
+            SemanticTokenType::OPERATOR,
+            SemanticTokenType::COMMENT,
+        ],
+        token_modifiers: Vec::<SemanticTokenModifier>::new(),
+    }
+}
+
+pub fn semantic_tokens_range(document: &Document, range: Range) -> Option<SemanticTokens> {
+    let emit_start = document.position_to_offset(range.start)?;
+    let emit_end = document.position_to_offset(range.end)?;
+    if emit_end < emit_start {
+        return None;
+    }
+
+    let scan_start = document
+        .line_offsets
+        .get(range.start.line as usize)
+        .copied()
+        .unwrap_or(emit_start);
+    let raw_tokens = lexer::lex_range(&document.text, scan_start, emit_end, emit_start, emit_end);
+
+    Some(SemanticTokens {
+        result_id: None,
+        data: encode_tokens(document, &raw_tokens, emit_start, emit_end)?,
+    })
+}
+
+fn encode_tokens(
+    document: &Document,
+    raw_tokens: &[LexedToken],
+    emit_start: usize,
+    emit_end: usize,
+) -> Option<Vec<SemanticToken>> {
+    let mut encoded = Vec::new();
+    let mut previous_start: Option<Position> = None;
+
+    for raw_token in raw_tokens {
+        for (start, end) in split_token(document, raw_token, emit_start, emit_end)? {
+            let start_position = document.offset_to_position(start)?;
+            let end_position = document.offset_to_position(end)?;
+            if start_position.line != end_position.line
+                || end_position.character <= start_position.character
+            {
+                continue;
+            }
+
+            let (delta_line, delta_start) = match previous_start {
+                Some(previous) if previous.line == start_position.line => (
+                    0,
+                    start_position.character.saturating_sub(previous.character),
+                ),
+                Some(previous) => (
+                    start_position.line.saturating_sub(previous.line),
+                    start_position.character,
+                ),
+                None => (start_position.line, start_position.character),
+            };
+
+            encoded.push(SemanticToken {
+                delta_line,
+                delta_start,
+                length: end_position.character - start_position.character,
+                token_type: token_type_index(raw_token.kind),
+                token_modifiers_bitset: 0,
+            });
+            previous_start = Some(start_position);
+        }
+    }
+
+    Some(encoded)
+}
+
+fn split_token(
+    document: &Document,
+    token: &LexedToken,
+    emit_start: usize,
+    emit_end: usize,
+) -> Option<Vec<(usize, usize)>> {
+    let start = token.start.max(emit_start);
+    let end = token.end.min(emit_end);
+    if start >= end {
+        return Some(Vec::new());
+    }
+
+    let start_line = line_index_for_offset(&document.line_offsets, start)?;
+    let end_line = line_index_for_offset(&document.line_offsets, end)?;
+    let mut ranges = Vec::new();
+
+    for line in start_line..=end_line {
+        let line_start = document.line_offsets[line];
+        let line_end = line_end_offset(&document.text, &document.line_offsets, line);
+        let segment_start = start.max(line_start);
+        let segment_end = end.min(line_end);
+        if segment_start < segment_end {
+            ranges.push((segment_start, segment_end));
+        }
+    }
+
+    Some(ranges)
+}
+
+fn line_index_for_offset(line_offsets: &[usize], offset: usize) -> Option<usize> {
+    match line_offsets.binary_search(&offset) {
+        Ok(line) => Some(line),
+        Err(next_line) => next_line.checked_sub(1),
+    }
+}
+
+fn line_end_offset(text: &str, line_offsets: &[usize], line_index: usize) -> usize {
+    let line_start = line_offsets[line_index];
+    let next_line_start = line_offsets
+        .get(line_index + 1)
+        .copied()
+        .unwrap_or(text.len());
+    if next_line_start > line_start
+        && text
+            .as_bytes()
+            .get(next_line_start - 1)
+            .is_some_and(|byte| *byte == b'\n')
+    {
+        next_line_start - 1
+    } else {
+        next_line_start
+    }
+}
+
+fn token_type_index(kind: TokenKind) -> u32 {
+    match kind {
+        TokenKind::Keyword => 0,
+        TokenKind::Class => 1,
+        TokenKind::Variable => 2,
+        TokenKind::String => 3,
+        TokenKind::Number => 4,
+        TokenKind::EnumMember => 5,
+        TokenKind::Operator => 6,
+        TokenKind::Comment => 7,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_range_tokens_with_absolute_positions() {
+        let text = "DATA;\n#1=IFCWALL(#2);\n#2=IFCDOOR();";
+        let document = Document::new_unloaded(text.to_string());
+        let range = Range {
+            start: Position::new(1, 0),
+            end: Position::new(2, 0),
+        };
+
+        let tokens = semantic_tokens_range(&document, range).unwrap();
+
+        assert_eq!(tokens.data[0].delta_line, 1);
+        assert_eq!(tokens.data[0].delta_start, 0);
+        assert_eq!(tokens.data[0].length, 2);
+        assert_eq!(
+            tokens.data[0].token_type,
+            token_type_index(TokenKind::Variable)
+        );
+        assert!(
+            tokens
+                .data
+                .iter()
+                .all(|token| token.delta_line == 0 || token.delta_line == 1)
+        );
+    }
+
+    #[test]
+    fn clamps_token_that_intersects_requested_range() {
+        let text = "#1=IFCWALL();";
+        let document = Document::new_unloaded(text.to_string());
+        let range = Range {
+            start: Position::new(0, 3),
+            end: Position::new(0, 7),
+        };
+
+        let tokens = semantic_tokens_range(&document, range).unwrap();
+
+        assert_eq!(tokens.data[0].delta_line, 0);
+        assert_eq!(tokens.data[0].delta_start, 3);
+        assert_eq!(tokens.data[0].length, 4);
+        assert_eq!(
+            tokens.data[0].token_type,
+            token_type_index(TokenKind::Class)
+        );
+    }
+
+    #[test]
+    fn splits_multiline_comment_tokens() {
+        let text = "/* first\nsecond */\n#1=IFCWALL();";
+        let document = Document::new_unloaded(text.to_string());
+        let range = Range {
+            start: Position::new(0, 0),
+            end: Position::new(2, 0),
+        };
+
+        let tokens = semantic_tokens_range(&document, range).unwrap();
+
+        assert_eq!(
+            tokens.data[0].token_type,
+            token_type_index(TokenKind::Comment)
+        );
+        assert_eq!(tokens.data[0].length, 8);
+        assert_eq!(tokens.data[1].delta_line, 1);
+        assert_eq!(tokens.data[1].delta_start, 0);
+        assert_eq!(
+            tokens.data[1].token_type,
+            token_type_index(TokenKind::Comment)
+        );
+    }
+}

--- a/src/features/semantic_tokens.rs
+++ b/src/features/semantic_tokens.rs
@@ -2,7 +2,6 @@
 //! This module converts lexer output into LSP semantic-token deltas while keeping the lexer free
 //! of protocol types.
 
-#[path = "semantic_tokens/lexer.rs"]
 mod lexer;
 
 use tower_lsp::lsp_types::{

--- a/src/features/semantic_tokens/lexer.rs
+++ b/src/features/semantic_tokens/lexer.rs
@@ -1,0 +1,285 @@
+//! Lightweight IFC semantic-token lexer.
+//! It scans borrowed document text and emits absolute byte ranges so callers can decide how to
+//! convert tokens into protocol-specific positions.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TokenKind {
+    Keyword,
+    Class,
+    Variable,
+    String,
+    Number,
+    EnumMember,
+    Operator,
+    Comment,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LexedToken {
+    pub kind: TokenKind,
+    pub start: usize,
+    pub end: usize,
+}
+
+pub fn lex_range(
+    text: &str,
+    scan_start: usize,
+    scan_end: usize,
+    emit_start: usize,
+    emit_end: usize,
+) -> Vec<LexedToken> {
+    let bytes = text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut offset = scan_start;
+
+    while offset < scan_end {
+        let byte = bytes[offset];
+        let token = match byte {
+            b'/' if bytes.get(offset + 1) == Some(&b'*') => {
+                let end = scan_block_comment(bytes, offset, scan_end);
+                Some((TokenKind::Comment, offset, end))
+            }
+            b'\'' => {
+                let end = scan_string(bytes, offset, scan_end);
+                Some((TokenKind::String, offset, end))
+            }
+            b'#' => scan_instance_id(bytes, offset, scan_end)
+                .map(|end| (TokenKind::Variable, offset, end)),
+            b'.' => scan_enum_member(bytes, offset, scan_end)
+                .map(|end| (TokenKind::EnumMember, offset, end)),
+            b'+' | b'-' if starts_number(bytes, offset, scan_end) => {
+                let end = scan_number(bytes, offset, scan_end);
+                Some((TokenKind::Number, offset, end))
+            }
+            byte if byte.is_ascii_digit() => {
+                let end = scan_number(bytes, offset, scan_end);
+                Some((TokenKind::Number, offset, end))
+            }
+            byte if is_identifier_start(byte) => {
+                let end = scan_identifier(bytes, offset, scan_end);
+                let kind = if is_keyword(&bytes[offset..end]) {
+                    TokenKind::Keyword
+                } else {
+                    TokenKind::Class
+                };
+                Some((kind, offset, end))
+            }
+            b'=' | b';' | b',' | b'(' | b')' | b'$' | b'*' => {
+                Some((TokenKind::Operator, offset, offset + 1))
+            }
+            _ => None,
+        };
+
+        if let Some((kind, start, end)) = token {
+            push_if_intersects(&mut tokens, kind, start, end, emit_start, emit_end);
+            offset = end;
+        } else {
+            offset += 1;
+        }
+    }
+
+    tokens
+}
+
+fn push_if_intersects(
+    tokens: &mut Vec<LexedToken>,
+    kind: TokenKind,
+    start: usize,
+    end: usize,
+    emit_start: usize,
+    emit_end: usize,
+) {
+    if start < emit_end && end > emit_start {
+        tokens.push(LexedToken { kind, start, end });
+    }
+}
+
+fn scan_block_comment(bytes: &[u8], mut offset: usize, scan_end: usize) -> usize {
+    offset += 2;
+    while offset + 1 < scan_end {
+        if bytes[offset] == b'*' && bytes[offset + 1] == b'/' {
+            return offset + 2;
+        }
+        offset += 1;
+    }
+    scan_end
+}
+
+fn scan_string(bytes: &[u8], mut offset: usize, scan_end: usize) -> usize {
+    offset += 1;
+    while offset < scan_end {
+        if bytes[offset] == b'\'' {
+            if bytes.get(offset + 1) == Some(&b'\'') && offset + 1 < scan_end {
+                offset += 2;
+            } else {
+                return offset + 1;
+            }
+        } else {
+            offset += 1;
+        }
+    }
+    scan_end
+}
+
+fn scan_instance_id(bytes: &[u8], mut offset: usize, scan_end: usize) -> Option<usize> {
+    offset += 1;
+    let start = offset;
+    while offset < scan_end && bytes[offset].is_ascii_digit() {
+        offset += 1;
+    }
+    (offset > start).then_some(offset)
+}
+
+fn scan_enum_member(bytes: &[u8], mut offset: usize, scan_end: usize) -> Option<usize> {
+    offset += 1;
+    let start = offset;
+    while offset < scan_end && is_identifier_part(bytes[offset]) {
+        offset += 1;
+    }
+    if offset == start || bytes.get(offset) != Some(&b'.') {
+        return None;
+    }
+    Some(offset + 1)
+}
+
+fn starts_number(bytes: &[u8], offset: usize, scan_end: usize) -> bool {
+    offset + 1 < scan_end && bytes[offset + 1].is_ascii_digit()
+}
+
+fn scan_number(bytes: &[u8], mut offset: usize, scan_end: usize) -> usize {
+    if matches!(bytes[offset], b'+' | b'-') {
+        offset += 1;
+    }
+
+    while offset < scan_end && bytes[offset].is_ascii_digit() {
+        offset += 1;
+    }
+
+    if bytes.get(offset) == Some(&b'.')
+        && bytes
+            .get(offset + 1)
+            .is_some_and(|byte| byte.is_ascii_digit())
+    {
+        offset += 1;
+        while offset < scan_end && bytes[offset].is_ascii_digit() {
+            offset += 1;
+        }
+    }
+
+    if matches!(bytes.get(offset), Some(b'E' | b'e')) {
+        let exponent_start = offset;
+        offset += 1;
+        if matches!(bytes.get(offset), Some(b'+' | b'-')) {
+            offset += 1;
+        }
+        let digit_start = offset;
+        while offset < scan_end && bytes[offset].is_ascii_digit() {
+            offset += 1;
+        }
+        if offset == digit_start {
+            return exponent_start;
+        }
+    }
+
+    offset
+}
+
+fn scan_identifier(bytes: &[u8], mut offset: usize, scan_end: usize) -> usize {
+    offset += 1;
+    while offset < scan_end && is_identifier_part(bytes[offset]) {
+        offset += 1;
+    }
+    offset
+}
+
+fn is_keyword(text: &[u8]) -> bool {
+    matches!(
+        text,
+        keyword if eq_ignore_ascii_case(keyword, b"ISO")
+            || eq_ignore_ascii_case(keyword, b"HEADER")
+            || eq_ignore_ascii_case(keyword, b"ENDSEC")
+            || eq_ignore_ascii_case(keyword, b"DATA")
+            || eq_ignore_ascii_case(keyword, b"END")
+            || eq_ignore_ascii_case(keyword, b"FILE_DESCRIPTION")
+            || eq_ignore_ascii_case(keyword, b"FILE_NAME")
+            || eq_ignore_ascii_case(keyword, b"FILE_SCHEMA")
+    )
+}
+
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn is_identifier_part(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+fn eq_ignore_ascii_case(left: &[u8], right: &[u8]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(left, right)| left.eq_ignore_ascii_case(right))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lexes_ifc_instance_tokens() {
+        let text = "#1=IFCWALL('A''B',#2,12.5,.T.,$,*);";
+
+        let tokens = lex_range(text, 0, text.len(), 0, text.len());
+
+        assert_eq!(
+            tokens
+                .iter()
+                .map(|token| token.kind)
+                .collect::<Vec<TokenKind>>(),
+            vec![
+                TokenKind::Variable,
+                TokenKind::Operator,
+                TokenKind::Class,
+                TokenKind::Operator,
+                TokenKind::String,
+                TokenKind::Operator,
+                TokenKind::Variable,
+                TokenKind::Operator,
+                TokenKind::Number,
+                TokenKind::Operator,
+                TokenKind::EnumMember,
+                TokenKind::Operator,
+                TokenKind::Operator,
+                TokenKind::Operator,
+                TokenKind::Operator,
+                TokenKind::Operator,
+                TokenKind::Operator,
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_fake_tokens_inside_strings_and_comments() {
+        let text = "'#1=IFCWALL';/* #2=IFCDOOR; */#3=IFCWINDOW();";
+
+        let tokens = lex_range(text, 0, text.len(), 0, text.len());
+
+        assert_eq!(tokens[0].kind, TokenKind::String);
+        assert_eq!(tokens[1].kind, TokenKind::Operator);
+        assert_eq!(tokens[2].kind, TokenKind::Comment);
+        assert_eq!(tokens[3].kind, TokenKind::Variable);
+        assert_eq!(&text[tokens[3].start..tokens[3].end], "#3");
+    }
+
+    #[test]
+    fn only_emits_tokens_intersecting_range() {
+        let text = "#1=IFCWALL();\n#2=IFCDOOR();";
+        let range_start = text.find("#2").unwrap();
+
+        let tokens = lex_range(text, 0, text.len(), range_start, text.len());
+
+        assert_eq!(&text[tokens[0].start..tokens[0].end], "#2");
+        assert!(tokens.iter().all(|token| token.end > range_start));
+    }
+}


### PR DESCRIPTION
This PR adds range-based semantic token support for IFC STEP files.

closes #60.

Semantic tokens are provided without relying on tree-sitter or schema docs, so syntax highlighting remains available for large files even if AST parsing is skipped or editor-side grammars stop highlighting the full file.
We are currently tokenizing: keywords, entity/type names, instance ids, strings, numbers, enum members, operators, and block comments.

Full document tokens are currently not supported, but could be added in the future if necessary using the same lexer.

## Changes
- Advertise textDocument/semanticTokens/range
- Add initializationOptions.semanticTokensEnabled, defaulting to true
- Add a small semantic-token handler plus a decoupled IFC/STEP lexer

The Screenshot shows semantic token based highlighting in VS-Code (the colors are exagerated for debugging :) )
<img width="1078" height="818" alt="Screenshot 2026-05-29 at 14 22 24" src="https://github.com/user-attachments/assets/0989b085-9e33-4b01-9bc6-2b94c9b76dbd" />
