### PR TITLE
Add macOS Intel release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,12 @@ jobs:
             asset_name: ifc-language-server-${{ github.ref_name }}-macos-arm64.tar.gz
             rustflags: ""
 
+          - runner: macos-15-intel
+            os_name: macos-x86_64
+            bin_name: ifc-language-server
+            asset_name: ifc-language-server-${{ github.ref_name }}-macos-x86_64.tar.gz
+            rustflags: ""
+
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/test-macos-intel.yml
+++ b/.github/workflows/test-macos-intel.yml
@@ -25,3 +25,10 @@ jobs:
 
       - name: Verify binary architecture
         run: file target/release/ifc-language-server
+
+      - name: Upload Intel binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: ifc-language-server-macos-x86_64
+          path: target/release/ifc-language-server
+          if-no-files-found: error

--- a/.github/workflows/test-macos-intel.yml
+++ b/.github/workflows/test-macos-intel.yml
@@ -1,0 +1,27 @@
+name: Test macOS Intel build
+
+on:
+  push:
+    branches:
+      - add-macos-intel-release
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-15-intel
+
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run tests
+        run: cargo test --locked
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Verify binary architecture
+        run: file target/release/ifc-language-server


### PR DESCRIPTION
- add a macOS x86_64 release job using the `macos-15-intel` runner
- publish the Intel binary as a separate release archive
