### PR TITLE
Add Rust project hygiene checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,23 +1,38 @@
-name: test-dev
+name: CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [dev, production]
   pull_request:
-    branches: [ "dev" ]
+    branches: [dev, production]
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-and-test:
+  verify:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out repository
+        uses: actions/checkout@v6
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      - name: Build
-        run: cargo build --verbose
+        with:
+          components: clippy, rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Lint
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --locked
+
+      - name: Build release binary
+        run: cargo build --release --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Lint
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version 0.22.2
+
+      - name: Audit dependencies
+        run: cargo audit
+
       - name: Run tests
         run: cargo test --locked
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -76,8 +76,12 @@ The following commands must pass for a change to be verified:
 
 ```bash
 cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo audit
 cargo test --locked
 cargo build --release --locked
 ```
+
+`cargo audit` requires `cargo-audit` 0.22.2 or newer.
 
 If the tests fail repeatedly when implementing a new feature, the run should be halted and the issues presented to the user.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -131,13 +131,13 @@ impl Backend {
             return Vec::new();
         }
 
-        let selected_schema_name = self.selected_schema_name(&document).await;
+        let selected_schema_name = self.selected_schema_name(document).await;
         if let Some(schema_name) = selected_schema_name.as_deref() {
             let schema_docs = self.schema_docs.read().await;
             let diagnostics = schema_docs
                 .get(schema_name)
                 .map(|schema| {
-                    diagnostics::collect_with_schema_name(&document, schema, Some(schema_name))
+                    diagnostics::collect_with_schema_name(document, schema, Some(schema_name))
                 })
                 .unwrap_or_default();
             debug!(

--- a/src/document.rs
+++ b/src/document.rs
@@ -432,10 +432,10 @@ fn traverse(cursor: &mut TreeCursor, text: &str, instances: &mut Vec<EntityInsta
     loop {
         let node = cursor.node();
 
-        if node.kind() == "entity_instance" {
-            if let Some(instance) = parse_entity_instance(node, text) {
-                instances.push(instance);
-            }
+        if node.kind() == "entity_instance"
+            && let Some(instance) = parse_entity_instance(node, text)
+        {
+            instances.push(instance);
         }
 
         if cursor.goto_first_child() {

--- a/src/schema/resolver.rs
+++ b/src/schema/resolver.rs
@@ -69,7 +69,7 @@ fn resolve_all_attributes(
     }));
 
     for attribute in &mut attributes {
-        if matches_derived_override(attribute, &derived_attributes) {
+        if matches_derived_override(attribute, derived_attributes) {
             attribute.allows_omitted = true;
         }
     }


### PR DESCRIPTION
## Summary

- resolve the existing Clippy warnings without broad source reformatting
- enforce rustfmt, Clippy, locked tests, and a locked release build in CI on `dev` and `production`
- group weekly Cargo and GitHub Actions Dependabot updates behind a seven-day cooldown
- run pinned RustSec dependency audits in CI and document the local verification commands

## Formatting

The existing tree already passes `cargo fmt --check`. Running `cargo fmt` after these changes produced no diff, so this PR contains no formatting-only churn and no artificial formatting commit.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo audit`
- `cargo test --locked` (69 passed)
- `cargo build --release --locked`
- all workflow and Dependabot YAML parses successfully

`cargo audit` reports no vulnerabilities. It reports five allowed transitive warnings from `espr` through its legacy `structopt` dependency chain.